### PR TITLE
chores: updated wallet context

### DIFF
--- a/soroban-client/contexts/WalletContext.tsx
+++ b/soroban-client/contexts/WalletContext.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import {
     isConnected,
+    isAllowed,
     requestAccess,
 } from "@stellar/freighter-api";
 
@@ -25,13 +26,26 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     });
     const [isInstalled, setIsInstalled] = useState<boolean>(false);
 
-    useEffect(() => {
+useEffect(() => {
         const checkInstallation = async () => {
             try {
-                const installed = await isConnected();
-                setIsInstalled(!!installed);
+                const result = await isConnected();
+                const installed = result.isConnected;
+                setIsInstalled(installed);
+
+                if (installed) {
+                    const savedAddress = localStorage.getItem('wallet_address');
+                    if (savedAddress) {
+                        const allowedResult = await isAllowed();
+                        if (!allowedResult.isAllowed) {
+                            setAddress(null);
+                            localStorage.removeItem('wallet_address');
+                        }
+                    }
+                }
             } catch (e) {
                 console.error("Freighter installation check failed", e);
+                setIsInstalled(false);
             }
         };
         checkInstallation();


### PR DESCRIPTION
Closes #45

## Problem

`isConnected()` from `@stellar/freighter-api` v6 returns an object
`{ isConnected: boolean }` — not a plain boolean.

from the original code on lines 31–32:
const installed = await isConnected();
setIsInstalled(!!installed);

In JavaScript, `!!anyObject` is always `true` — even `!!{ isConnected: false }`.
So `isInstalled` was permanently `true`, causing the Header to show
"Connect Wallet" instead of "Install Freighter" when Freighter was absent.
This affects both the desktop header and the new mobile menu.

## Fix

- Read `result.isConnected` from the object returned by `isConnected()`
- Added `isAllowed()` validation to clear stale localStorage sessions
  when Freighter access has been revoked since the last visit
- Added explicit `setIsInstalled(false)` in the catch block

## Testing

1. Without Freighter installed (incognito window) → shows "Install Freighter" ✅
2. With Freighter installed, not connected → shows "Connect Wallet" ✅
3. Connect wallet, revoke access in Freighter settings, refresh → resets to disconnected ✅