### PR TITLE
Changes made

### DIFF
--- a/soroban-client/app/api/events/stream/route.ts
+++ b/soroban-client/app/api/events/stream/route.ts
@@ -2,8 +2,13 @@
  * GET /api/events/stream
  *
  * Server-Sent Events stream for real-time contract event updates.
- * The client receives a "events" message every POLL_INTERVAL_MS with
- * any new indexed events since the last push.
+ * Supports cursor-based reconnection to replay missed events.
+ *
+ * Query params:
+ *   cursor  – Optional cursor to resume from (format: "ledger-0-0-0")
+ *
+ * Headers:
+ *   Last-Event-ID – Auto-sent by browser on reconnect, contains last event ID
  *
  * Usage (browser):
  *   const es = new EventSource('/api/events/stream');
@@ -12,30 +17,63 @@
  */
 
 import { NextRequest } from "next/server";
-import { getIndexedEvents } from "@/lib/indexer";
+import { getIndexedEvents, getEventsAfterCursor, getLatestCursor } from "@/lib/indexer";
 
 export const dynamic = "force-dynamic";
 
 const POLL_INTERVAL_MS = 5_000;
 const HEARTBEAT_INTERVAL_MS = 20_000;
 
-export async function GET(_req: NextRequest) {
+export async function GET(req: NextRequest) {
   let closed = false;
   let lastEventId = "";
+  let cursor = "";
+
+  // Extract cursor from query params for reconnection
+  const urlCursor = req.nextUrl.searchParams.get('cursor');
+  if (urlCursor) {
+    cursor = urlCursor;
+  }
 
   const stream = new ReadableStream({
     async start(controller) {
       const enc = new TextEncoder();
 
-      const send = (event: string, data: string) => {
+      const send = (event: string, data: string, id?: string) => {
         if (closed) return;
-        controller.enqueue(enc.encode(`event: ${event}\ndata: ${data}\n\n`));
+        let message = `event: ${event}\ndata: ${data}\n`;
+        if (id) {
+          message += `id: ${id}\n`;
+        }
+        message += `\n`;
+        controller.enqueue(enc.encode(message));
       };
 
-      // Initial snapshot
-      const initial = await getIndexedEvents();
-      if (initial.length > 0) lastEventId = initial[initial.length - 1].id;
-      send("events", JSON.stringify({ events: initial, type: "snapshot" }));
+      // Determine which events to send based on cursor
+      let initialEvents: Awaited<ReturnType<typeof getIndexedEvents>>;
+      if (cursor) {
+        // Replay events after the cursor for reconnection
+        initialEvents = getEventsAfterCursor(cursor);
+        send("reconnect", JSON.stringify({ 
+          events: initialEvents, 
+          type: "replay",
+          cursor: cursor 
+        }));
+      } else {
+        // Initial snapshot
+        initialEvents = await getIndexedEvents();
+        if (initialEvents.length > 0) {
+          lastEventId = initialEvents[initialEvents.length - 1].id;
+        }
+        send("events", JSON.stringify({ events: initialEvents, type: "snapshot" }), lastEventId || undefined);
+      }
+
+      // Update cursor tracking
+      if (initialEvents.length > 0) {
+        const latestEvent = initialEvents[initialEvents.length - 1];
+        cursor = `${latestEvent.ledger}-0-0-0`;
+        lastEventId = latestEvent.id;
+      }
 
       // Polling loop
       const pollTimer = setInterval(async () => {
@@ -46,7 +84,8 @@ export async function GET(_req: NextRequest) {
           const newEvents = lastIdx === -1 ? all : all.slice(lastIdx + 1);
           if (newEvents.length > 0) {
             lastEventId = newEvents[newEvents.length - 1].id;
-            send("events", JSON.stringify({ events: newEvents, type: "update" }));
+            cursor = `${newEvents[newEvents.length - 1].ledger}-0-0-0`;
+            send("events", JSON.stringify({ events: newEvents, type: "update" }), lastEventId);
           }
         } catch {
           // swallow — client will reconnect via SSE retry

--- a/soroban-client/hooks/useContractEvents.ts
+++ b/soroban-client/hooks/useContractEvents.ts
@@ -37,6 +37,10 @@ export function useContractEvents(
   const [error, setError] = useState<string | null>(null);
   const [updatedAt, setUpdatedAt] = useState(0);
   const esRef = useRef<EventSource | null>(null);
+  const cursorRef = useRef<string>("");
+  const reconnectAttemptsRef = useRef(0);
+  const maxReconnectAttempts = 10;
+  const reconnectDelayRef = useRef(1000); // Start with 1s delay
 
   const buildUrl = useCallback(() => {
     const sp = new URLSearchParams();
@@ -84,29 +88,106 @@ export function useContractEvents(
   useEffect(() => {
     if (!realtime) return;
 
-    const es = new EventSource("/api/events/stream");
-    esRef.current = es;
+    const connectSSE = () => {
+      // Build URL with cursor for reconnection
+      const streamUrl = cursorRef.current 
+        ? `/api/events/stream?cursor=${encodeURIComponent(cursorRef.current)}`
+        : '/api/events/stream';
 
-    es.addEventListener("events", (e: MessageEvent) => {
-      try {
-        const payload = JSON.parse(e.data as string) as {
-          events: IndexedEvent[];
-          type: "snapshot" | "update";
-        };
-        if (payload.type === "update" && payload.events.length > 0) {
-          // Re-fetch with current filters to get accurate filtered results
-          void fetchEvents();
+      const es = new EventSource(streamUrl);
+      esRef.current = es;
+
+      es.addEventListener("events", (e: MessageEvent) => {
+        try {
+          const payload = JSON.parse(e.data as string) as {
+            events: IndexedEvent[];
+            type: "snapshot" | "update";
+          };
+          
+          if (payload.type === "snapshot") {
+            setEvents(payload.events);
+            setTotal(payload.events.length);
+          } else if (payload.type === "update" && payload.events.length > 0) {
+            // Re-fetch with current filters to get accurate filtered results
+            void fetchEvents();
+          }
+          
+          // Update cursor from event ID
+          if (payload.events.length > 0) {
+            const lastEvent = payload.events[payload.events.length - 1];
+            cursorRef.current = `${lastEvent.ledger}-0-0-0`;
+          }
+          
+          // Reset reconnect attempts on successful connection
+          reconnectAttemptsRef.current = 0;
+          reconnectDelayRef.current = 1000;
+        } catch { /* ignore parse errors */ }
+      });
+
+      // Handle reconnection/replay events
+      es.addEventListener("reconnect", (e: MessageEvent) => {
+        try {
+          const payload = JSON.parse(e.data as string) as {
+            events: IndexedEvent[];
+            type: "replay";
+            cursor: string;
+          };
+          
+          if (payload.type === "replay" && payload.events.length > 0) {
+            // Merge replayed events with existing events
+            setEvents((prev: IndexedEvent[]) => {
+              const existingIds = new Set(prev.map((e: IndexedEvent) => e.id));
+              const newEvents = payload.events.filter((e: IndexedEvent) => !existingIds.has(e.id));
+              return [...prev, ...newEvents];
+            });
+            void fetchEvents();
+          }
+          
+          // Update cursor
+          if (payload.cursor) {
+            cursorRef.current = payload.cursor;
+          }
+          
+          // Reset reconnect attempts
+          reconnectAttemptsRef.current = 0;
+          reconnectDelayRef.current = 1000;
+        } catch { /* ignore parse errors */ }
+      });
+
+      es.addEventListener("heartbeat", () => {
+        // Connection is alive
+      });
+
+      es.onerror = () => {
+        // Connection dropped - will attempt to reconnect with cursor
+        console.warn('SSE connection dropped, will reconnect with cursor:', cursorRef.current);
+        
+        // Close the current connection
+        es.close();
+        esRef.current = null;
+        
+        // Implement exponential backoff for reconnection
+        if (reconnectAttemptsRef.current < maxReconnectAttempts) {
+          const delay = reconnectDelayRef.current;
+          reconnectAttemptsRef.current++;
+          // Exponential backoff: double the delay each time, max 30s
+          reconnectDelayRef.current = Math.min(reconnectDelayRef.current * 2, 30000);
+          
+          console.log(`Reconnecting in ${delay}ms (attempt ${reconnectAttemptsRef.current}/${maxReconnectAttempts})`);
+          setTimeout(connectSSE, delay);
+        } else {
+          setError('Failed to maintain connection after maximum retries');
         }
-      } catch { /* ignore parse errors */ }
-    });
-
-    es.onerror = () => {
-      // Browser will auto-reconnect SSE; no action needed
+      };
     };
 
+    connectSSE();
+
     return () => {
-      es.close();
-      esRef.current = null;
+      if (esRef.current) {
+        esRef.current.close();
+        esRef.current = null;
+      }
     };
   }, [realtime, fetchEvents]);
 

--- a/soroban-client/lib/indexer.ts
+++ b/soroban-client/lib/indexer.ts
@@ -278,3 +278,32 @@ export function getCacheStats() {
     ttlMs: CACHE_TTL_MS,
   };
 }
+
+/**
+ * Get the latest cursor for reconnection purposes
+ * Returns a cursor string that can be used to resume from the last known position
+ */
+export function getLatestCursor(): string | null {
+  if (cache.lastLedger === 0) return null;
+  return `${cache.lastLedger}-0-0-0`;
+}
+
+/**
+ * Get events after a specific cursor for replay
+ * @param cursor The cursor to resume from (format: "ledger-0-0-0")
+ * @returns Events that occurred after the cursor
+ */
+export function getEventsAfterCursor(cursor: string): IndexedEvent[] {
+  if (!cursor || cache.lastLedger === 0) {
+    return cache.events;
+  }
+
+  // Parse the cursor to extract the ledger number
+  const cursorLedger = parseInt(cursor.split('-')[0], 10);
+  if (isNaN(cursorLedger)) {
+    return cache.events;
+  }
+
+  // Return events that occurred after the cursor ledger
+  return cache.events.filter(event => event.ledger > cursorLedger);
+}


### PR DESCRIPTION
## Description
Implement cursor-aware reconnection and replay for dropped SSE (Server-Sent Events) sessions in the event streaming system. This ensures no events are lost during temporary connection drops by tracking the last known cursor position and automatically replaying missed events upon reconnection.
Fixes #234 

## Type of Change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring
- [ ] Performance improvement


## Changes Made
- Enhanced indexer with getLatestCursor() and getEventsAfterCursor() functions for cursor tracking and event replay
- Updated SSE stream endpoint (/api/events/stream) to accept cursor query parameter and send cursor-aware events with ID tracking
- Modified useContractEvents hook to implement automatic reconnection with exponential backoff (1s to 30s)
- Added cursor-based event replay mechanism that merges missed events without duplicates
- Implemented reconnection event handler with maximum retry limit (10 attempts) and error handling

## Testing
Please describe the tests that you ran to verify your changes:
- [ ]  Manual testing of SSE connection drop and reconnection with cursor-based replay
- [ ]  Verified exponential backoff behavior during reconnection attempts
- [ ] Confirmed event deduplication when merging replayed events
- [ ] Tested cursor tracking accuracy across multiple connection cycles

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
1. Client connects to /api/events/stream and receives events with cursor tracking
2. On connection drop, client automatically reconnects with last known cursor: /api/events/stream?cursor=<ledger>-0-0-0
3. Server replays all events that occurred after the cursor as a "reconnect" event
4. Client merges replayed events with existing state (deduplication by ID)
5. Normal streaming resumes from the reconnection point

