### PR TITLE
feat(soroban-client): contract schema cache with invalidation (#231)

### DIFF
--- a/soroban-client/__tests__/lib/contractSchemaCache.test.ts
+++ b/soroban-client/__tests__/lib/contractSchemaCache.test.ts
@@ -1,0 +1,350 @@
+import {
+  ContractSchemaCache,
+  MemorySchemaStore,
+  WebStorageSchemaStore,
+  staticSchemaResolver,
+  type ContractSchema,
+  type SchemaCacheEvent,
+  type SchemaIdentityProbe,
+  type SchemaResolver,
+} from "@/sdk/src/schemaCache";
+
+const CONTRACT_ID = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+
+function makeSchema(
+  overrides: Partial<Omit<ContractSchema, "fetchedAt">> = {}
+): Omit<ContractSchema, "fetchedAt"> {
+  return {
+    contractId: CONTRACT_ID,
+    version: 1,
+    wasmHash: "deadbeef",
+    methods: [
+      { name: "ping", args: [], returns: "u32", mutates: false },
+    ],
+    errors: [{ name: "Unauthorized", code: 1 }],
+    ...overrides,
+  };
+}
+
+class StubResolver implements SchemaResolver {
+  public readonly calls: string[] = [];
+  private readonly responses: Array<Omit<ContractSchema, "fetchedAt">>;
+
+  constructor(responses: Array<Omit<ContractSchema, "fetchedAt">>) {
+    this.responses = responses;
+  }
+
+  async resolve(contractId: string) {
+    this.calls.push(contractId);
+    if (this.responses.length === 0) {
+      throw new Error("StubResolver: no more responses queued");
+    }
+    return this.responses.shift()!;
+  }
+}
+
+class StubProbe implements SchemaIdentityProbe {
+  public readonly calls: string[] = [];
+  private readonly responses: Array<{ version: number; wasmHash: string }>;
+
+  constructor(responses: Array<{ version: number; wasmHash: string }>) {
+    this.responses = responses;
+  }
+
+  async probe(contractId: string) {
+    this.calls.push(contractId);
+    if (this.responses.length === 0) {
+      throw new Error("StubProbe: no more responses queued");
+    }
+    return this.responses.shift()!;
+  }
+}
+
+describe("ContractSchemaCache", () => {
+  it("fetches and stores on first access", async () => {
+    const resolver = new StubResolver([makeSchema()]);
+    const cache = new ContractSchemaCache({ resolver, now: () => 1_000 });
+
+    const schema = await cache.get(CONTRACT_ID);
+
+    expect(schema.contractId).toBe(CONTRACT_ID);
+    expect(schema.version).toBe(1);
+    expect(schema.fetchedAt).toBe(1_000);
+    expect(resolver.calls).toEqual([CONTRACT_ID]);
+  });
+
+  it("returns the cached entry without refetching when probe matches", async () => {
+    const resolver = new StubResolver([makeSchema()]);
+    const probe = new StubProbe([{ version: 1, wasmHash: "deadbeef" }]);
+    const cache = new ContractSchemaCache({ resolver, probe });
+
+    await cache.get(CONTRACT_ID);
+    const second = await cache.get(CONTRACT_ID);
+
+    expect(second.version).toBe(1);
+    expect(resolver.calls).toEqual([CONTRACT_ID]);
+    expect(probe.calls).toEqual([CONTRACT_ID]);
+  });
+
+  it("refreshes when the on-chain version differs", async () => {
+    const resolver = new StubResolver([
+      makeSchema({ version: 1 }),
+      makeSchema({ version: 2 }),
+    ]);
+    const probe = new StubProbe([{ version: 2, wasmHash: "deadbeef" }]);
+    const cache = new ContractSchemaCache({ resolver, probe });
+
+    await cache.get(CONTRACT_ID);
+    const refreshed = await cache.get(CONTRACT_ID);
+
+    expect(refreshed.version).toBe(2);
+    expect(resolver.calls).toEqual([CONTRACT_ID, CONTRACT_ID]);
+  });
+
+  it("refreshes when the on-chain wasmHash differs", async () => {
+    const resolver = new StubResolver([
+      makeSchema({ wasmHash: "aaaa" }),
+      makeSchema({ wasmHash: "bbbb" }),
+    ]);
+    const probe = new StubProbe([{ version: 1, wasmHash: "bbbb" }]);
+    const cache = new ContractSchemaCache({ resolver, probe });
+
+    await cache.get(CONTRACT_ID);
+    const refreshed = await cache.get(CONTRACT_ID);
+
+    expect(refreshed.wasmHash).toBe("bbbb");
+    expect(resolver.calls).toEqual([CONTRACT_ID, CONTRACT_ID]);
+  });
+
+  it("never probes when no probe is configured", async () => {
+    const resolver = new StubResolver([makeSchema(), makeSchema({ version: 99 })]);
+    const cache = new ContractSchemaCache({ resolver });
+
+    const first = await cache.get(CONTRACT_ID);
+    const second = await cache.get(CONTRACT_ID);
+
+    expect(first.version).toBe(1);
+    expect(second.version).toBe(1); // still cached, despite the queued v99
+    expect(resolver.calls).toEqual([CONTRACT_ID]);
+  });
+
+  it("manual refresh forces a refetch even when fresh", async () => {
+    const resolver = new StubResolver([makeSchema(), makeSchema({ version: 5 })]);
+    const cache = new ContractSchemaCache({ resolver });
+
+    await cache.get(CONTRACT_ID);
+    const refreshed = await cache.refresh(CONTRACT_ID);
+
+    expect(refreshed.version).toBe(5);
+    expect(resolver.calls).toEqual([CONTRACT_ID, CONTRACT_ID]);
+  });
+
+  it("invalidate drops the entry", async () => {
+    const resolver = new StubResolver([makeSchema(), makeSchema({ version: 7 })]);
+    const cache = new ContractSchemaCache({ resolver });
+
+    await cache.get(CONTRACT_ID);
+    cache.invalidate(CONTRACT_ID);
+    expect(cache.peek(CONTRACT_ID)).toBeUndefined();
+
+    const next = await cache.get(CONTRACT_ID);
+    expect(next.version).toBe(7);
+  });
+
+  it("clear drops every entry", async () => {
+    const resolver = new StubResolver([
+      makeSchema({ contractId: "A" }),
+      makeSchema({ contractId: "B" }),
+    ]);
+    const cache = new ContractSchemaCache({ resolver });
+
+    await cache.get("A");
+    await cache.get("B");
+    cache.clear();
+
+    expect(cache.peek("A")).toBeUndefined();
+    expect(cache.peek("B")).toBeUndefined();
+  });
+
+  it("emits events for hits, misses, refreshes, and invalidations", async () => {
+    const resolver = new StubResolver([makeSchema(), makeSchema({ version: 3 })]);
+    const probe = new StubProbe([
+      { version: 1, wasmHash: "deadbeef" },
+      { version: 3, wasmHash: "deadbeef" },
+    ]);
+    const cache = new ContractSchemaCache({ resolver, probe });
+    const events: SchemaCacheEvent[] = [];
+    const unsubscribe = cache.subscribe((event) => events.push(event));
+
+    await cache.get(CONTRACT_ID); // miss + refreshed(missing)
+    await cache.get(CONTRACT_ID); // hit (probe match)
+    await cache.get(CONTRACT_ID); // refreshed(version)
+    cache.invalidate(CONTRACT_ID); // invalidated
+    unsubscribe();
+    cache.invalidate(CONTRACT_ID); // no event after unsubscribe & already empty
+
+    const types = events.map((e) => e.type);
+    expect(types).toEqual([
+      "miss",
+      "refreshed",
+      "hit",
+      "refreshed",
+      "invalidated",
+    ]);
+
+    const refreshedEvents = events.filter((e) => e.type === "refreshed");
+    expect(refreshedEvents[0]).toMatchObject({ reason: "missing" });
+    expect(refreshedEvents[1]).toMatchObject({ reason: "version" });
+  });
+
+  it("rejects schemas whose contractId does not match the request", async () => {
+    const resolver = new StubResolver([makeSchema({ contractId: "OTHER" })]);
+    const cache = new ContractSchemaCache({ resolver });
+
+    await expect(cache.get(CONTRACT_ID)).rejects.toThrow(/OTHER/);
+  });
+
+  it("propagates resolver errors and does not cache failures", async () => {
+    const failingResolver: SchemaResolver = {
+      resolve: jest.fn().mockRejectedValueOnce(new Error("boom")),
+    };
+    const cache = new ContractSchemaCache({ resolver: failingResolver });
+
+    await expect(cache.get(CONTRACT_ID)).rejects.toThrow("boom");
+    expect(cache.peek(CONTRACT_ID)).toBeUndefined();
+  });
+});
+
+describe("MemorySchemaStore", () => {
+  it("round-trips entries", () => {
+    const store = new MemorySchemaStore();
+    const schema: ContractSchema = { ...makeSchema(), fetchedAt: 1 };
+
+    expect(store.get(CONTRACT_ID)).toBeUndefined();
+    store.set(CONTRACT_ID, schema);
+    expect(store.get(CONTRACT_ID)).toEqual(schema);
+    expect(store.keys()).toEqual([CONTRACT_ID]);
+
+    store.delete(CONTRACT_ID);
+    expect(store.get(CONTRACT_ID)).toBeUndefined();
+    expect(store.keys()).toEqual([]);
+  });
+
+  it("clears every entry", () => {
+    const store = new MemorySchemaStore();
+    store.set("A", { ...makeSchema({ contractId: "A" }), fetchedAt: 1 });
+    store.set("B", { ...makeSchema({ contractId: "B" }), fetchedAt: 2 });
+    store.clear();
+    expect(store.keys()).toEqual([]);
+  });
+});
+
+class FakeStorage {
+  private readonly data = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.data.delete(key);
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.data.keys())[index] ?? null;
+  }
+
+  get length(): number {
+    return this.data.size;
+  }
+}
+
+describe("WebStorageSchemaStore", () => {
+  it("persists entries to and from the underlying storage", () => {
+    const storage = new FakeStorage();
+    const store = new WebStorageSchemaStore(storage);
+    const schema: ContractSchema = { ...makeSchema(), fetchedAt: 5 };
+
+    store.set(CONTRACT_ID, schema);
+
+    const direct = storage.getItem(`tokenbound:schema:${CONTRACT_ID}`);
+    expect(direct).not.toBeNull();
+    expect(JSON.parse(direct as string).version).toBe(1);
+    expect(store.get(CONTRACT_ID)).toEqual(schema);
+  });
+
+  it("returns undefined for malformed JSON without throwing", () => {
+    const storage = new FakeStorage();
+    storage.setItem(`tokenbound:schema:${CONTRACT_ID}`, "{not json");
+    const store = new WebStorageSchemaStore(storage);
+
+    expect(store.get(CONTRACT_ID)).toBeUndefined();
+  });
+
+  it("returns undefined for entries missing required identity fields", () => {
+    const storage = new FakeStorage();
+    storage.setItem(
+      `tokenbound:schema:${CONTRACT_ID}`,
+      JSON.stringify({ contractId: CONTRACT_ID, methods: [] })
+    );
+    const store = new WebStorageSchemaStore(storage);
+
+    expect(store.get(CONTRACT_ID)).toBeUndefined();
+  });
+
+  it("only enumerates keys with the configured prefix", () => {
+    const storage = new FakeStorage();
+    storage.setItem("unrelated", "value");
+    const store = new WebStorageSchemaStore(storage, "myapp:");
+    store.set(CONTRACT_ID, { ...makeSchema(), fetchedAt: 0 });
+
+    expect(store.keys()).toEqual([CONTRACT_ID]);
+    expect(storage.getItem("unrelated")).toBe("value");
+
+    store.clear();
+    expect(store.keys()).toEqual([]);
+    expect(storage.getItem("unrelated")).toBe("value");
+  });
+
+  it("integrates end-to-end with the cache", async () => {
+    const storage = new FakeStorage();
+    const store = new WebStorageSchemaStore(storage);
+    const resolver = new StubResolver([makeSchema()]);
+    const cache = new ContractSchemaCache({ store, resolver, now: () => 42 });
+
+    const schema = await cache.get(CONTRACT_ID);
+
+    // Re-create the cache with the same storage — should not call the resolver again.
+    const probe = new StubProbe([{ version: 1, wasmHash: "deadbeef" }]);
+    const recoveredResolver = new StubResolver([]);
+    const recovered = new ContractSchemaCache({
+      store: new WebStorageSchemaStore(storage),
+      resolver: recoveredResolver,
+      probe,
+    });
+
+    const second = await recovered.get(CONTRACT_ID);
+    expect(second.fetchedAt).toBe(schema.fetchedAt);
+    expect(recoveredResolver.calls).toEqual([]);
+  });
+});
+
+describe("staticSchemaResolver", () => {
+  it("returns the registered schema", async () => {
+    const resolver = staticSchemaResolver({
+      [CONTRACT_ID]: makeSchema({ version: 9 }),
+    });
+
+    const schema = await resolver.resolve(CONTRACT_ID);
+    expect(schema.version).toBe(9);
+  });
+
+  it("throws for unknown contract ids", async () => {
+    const resolver = staticSchemaResolver({});
+    await expect(resolver.resolve(CONTRACT_ID)).rejects.toThrow(/No static schema/);
+  });
+});

--- a/soroban-client/sdk/README.md
+++ b/soroban-client/sdk/README.md
@@ -54,3 +54,47 @@ const result = await sdk.eventManager.createEvent(
 cd soroban-client
 npm run sdk:generate-types
 ```
+
+### Caching contract schemas at runtime
+
+Soroban contracts in this repo follow the upgradeable pattern, so each
+contract's deployed `version()` and WASM hash uniquely identify its
+on-chain spec. `ContractSchemaCache` caches a fetched spec keyed by that
+identity and refreshes automatically when either component changes:
+
+```ts
+import {
+  ContractSchemaCache,
+  WebStorageSchemaStore,
+  type SchemaIdentityProbe,
+  type SchemaResolver,
+} from "@crowdpass/tokenbound-sdk";
+
+const probe: SchemaIdentityProbe = {
+  async probe(contractId) {
+    const version = Number(await sdk.eventManager.version());
+    const wasmHash = await fetchWasmHash(contractId); // app-specific
+    return { version, wasmHash };
+  },
+};
+
+const resolver: SchemaResolver = {
+  async resolve(contractId) {
+    return loadSpecFromRpc(contractId); // app-specific
+  },
+};
+
+const schemaCache = new ContractSchemaCache({
+  store: new WebStorageSchemaStore(window.localStorage),
+  resolver,
+  probe,
+});
+
+const spec = await schemaCache.get(contractId);
+```
+
+`MemorySchemaStore` is used by default and is enough for server contexts;
+`WebStorageSchemaStore` persists across reloads in the browser. Omit
+`probe` if you only want to refresh on explicit `cache.refresh(...)` or
+`cache.invalidate(...)` calls. Subscribe via `cache.subscribe(listener)`
+to observe `hit` / `miss` / `refreshed` / `invalidated` events.

--- a/soroban-client/sdk/src/index.ts
+++ b/soroban-client/sdk/src/index.ts
@@ -13,6 +13,7 @@ export * from "./contracts";
 export * from "./core";
 export * from "./errors";
 export * from "./generated/contracts";
+export * from "./schemaCache";
 export * from "./types";
 
 export class TokenboundSdk extends SorobanSdkCore {

--- a/soroban-client/sdk/src/schemaCache.ts
+++ b/soroban-client/sdk/src/schemaCache.ts
@@ -1,0 +1,325 @@
+/**
+ * Contract schema cache with version- and hash-based invalidation.
+ *
+ * Soroban contracts in this repo follow the upgradeable pattern (see
+ * `soroban-contract/contracts/upgradeable`): every contract exposes
+ * `version()` (a monotonic counter bumped on each upgrade) and is backed by
+ * a WASM whose hash changes when the code changes. This module caches the
+ * full method/error spec for a contract keyed by `(contractId, version,
+ * wasmHash)` so callers do not refetch on every interaction, and refreshes
+ * automatically when either identity component changes.
+ *
+ * The module is intentionally free of any `@stellar/stellar-sdk` import:
+ * the resolver and probe are injectable interfaces. A reference RPC-backed
+ * resolver can live alongside but it is not required for the cache to be
+ * useful (e.g. tests, or builds that ship a pinned spec snapshot).
+ */
+
+export interface ContractMethodArg {
+  readonly name: string;
+  readonly type: string;
+}
+
+export interface ContractMethodSpec {
+  readonly name: string;
+  readonly args: readonly ContractMethodArg[];
+  readonly returns: string;
+  readonly mutates: boolean;
+}
+
+export interface ContractErrorSpec {
+  readonly name: string;
+  readonly code: number;
+}
+
+export interface ContractIdentity {
+  /** Stellar contract address, e.g. `C…`. */
+  readonly contractId: string;
+  /** Monotonic version exposed by the upgradeable library. */
+  readonly version: number;
+  /**
+   * Hex (or any opaque string) representation of the deployed WASM hash.
+   * The cache treats it as an opaque equality token.
+   */
+  readonly wasmHash: string;
+}
+
+export interface ContractSchema extends ContractIdentity {
+  readonly methods: readonly ContractMethodSpec[];
+  readonly errors: readonly ContractErrorSpec[];
+  /** Epoch milliseconds when this entry was written into the cache. */
+  readonly fetchedAt: number;
+}
+
+/**
+ * Cheap probe used to decide whether a cached entry is still valid. A real
+ * implementation will read the contract's `version()` and the WASM hash
+ * from the contract instance ledger entry; tests pass a stub.
+ */
+export interface SchemaIdentityProbe {
+  probe(contractId: string): Promise<{ version: number; wasmHash: string }>;
+}
+
+/**
+ * Loads a full schema for a contract. Called only when the cache is empty
+ * for that contract or when the probe reports an identity change.
+ */
+export interface SchemaResolver {
+  resolve(contractId: string): Promise<Omit<ContractSchema, "fetchedAt">>;
+}
+
+/** Pluggable persistence backend. Default is in-memory. */
+export interface SchemaStore {
+  get(contractId: string): ContractSchema | undefined;
+  set(contractId: string, schema: ContractSchema): void;
+  delete(contractId: string): void;
+  clear(): void;
+  keys(): readonly string[];
+}
+
+export class MemorySchemaStore implements SchemaStore {
+  private readonly entries = new Map<string, ContractSchema>();
+
+  get(contractId: string): ContractSchema | undefined {
+    return this.entries.get(contractId);
+  }
+
+  set(contractId: string, schema: ContractSchema): void {
+    this.entries.set(contractId, schema);
+  }
+
+  delete(contractId: string): void {
+    this.entries.delete(contractId);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  keys(): readonly string[] {
+    return Array.from(this.entries.keys());
+  }
+}
+
+/** Minimal Web Storage shape so this module does not depend on `lib.dom`. */
+export interface KeyValueStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+  key(index: number): string | null;
+  readonly length: number;
+}
+
+const DEFAULT_STORAGE_PREFIX = "tokenbound:schema:";
+
+/**
+ * Persists schemas in a `Storage` (localStorage / sessionStorage). Only
+ * entries whose key matches the configured prefix are touched — sharing
+ * the storage with unrelated data is safe.
+ */
+export class WebStorageSchemaStore implements SchemaStore {
+  private readonly storage: KeyValueStorage;
+  private readonly prefix: string;
+
+  constructor(storage: KeyValueStorage, prefix: string = DEFAULT_STORAGE_PREFIX) {
+    this.storage = storage;
+    this.prefix = prefix;
+  }
+
+  private storageKey(contractId: string): string {
+    return `${this.prefix}${contractId}`;
+  }
+
+  get(contractId: string): ContractSchema | undefined {
+    const raw = this.storage.getItem(this.storageKey(contractId));
+    if (!raw) {
+      return undefined;
+    }
+    try {
+      const parsed = JSON.parse(raw) as ContractSchema;
+      if (
+        typeof parsed?.contractId !== "string" ||
+        typeof parsed?.version !== "number" ||
+        typeof parsed?.wasmHash !== "string"
+      ) {
+        return undefined;
+      }
+      return parsed;
+    } catch {
+      return undefined;
+    }
+  }
+
+  set(contractId: string, schema: ContractSchema): void {
+    this.storage.setItem(this.storageKey(contractId), JSON.stringify(schema));
+  }
+
+  delete(contractId: string): void {
+    this.storage.removeItem(this.storageKey(contractId));
+  }
+
+  clear(): void {
+    for (const key of this.keys()) {
+      this.storage.removeItem(this.storageKey(key));
+    }
+  }
+
+  keys(): readonly string[] {
+    const result: string[] = [];
+    for (let index = 0; index < this.storage.length; index += 1) {
+      const key = this.storage.key(index);
+      if (key && key.startsWith(this.prefix)) {
+        result.push(key.slice(this.prefix.length));
+      }
+    }
+    return result;
+  }
+}
+
+export type SchemaCacheEvent =
+  | { readonly type: "hit"; readonly schema: ContractSchema }
+  | { readonly type: "miss"; readonly contractId: string }
+  | {
+      readonly type: "refreshed";
+      readonly schema: ContractSchema;
+      readonly previous: ContractSchema | undefined;
+      readonly reason: "missing" | "version" | "wasmHash" | "manual";
+    }
+  | { readonly type: "invalidated"; readonly contractId: string };
+
+export type SchemaCacheListener = (event: SchemaCacheEvent) => void;
+
+export interface ContractSchemaCacheOptions {
+  readonly store?: SchemaStore;
+  readonly resolver: SchemaResolver;
+  readonly probe?: SchemaIdentityProbe;
+  /** Defaults to `() => Date.now()`; overridable for deterministic tests. */
+  readonly now?: () => number;
+}
+
+export class ContractSchemaCache {
+  private readonly store: SchemaStore;
+  private readonly resolver: SchemaResolver;
+  private readonly probe: SchemaIdentityProbe | undefined;
+  private readonly now: () => number;
+  private readonly listeners = new Set<SchemaCacheListener>();
+
+  constructor(options: ContractSchemaCacheOptions) {
+    this.store = options.store ?? new MemorySchemaStore();
+    this.resolver = options.resolver;
+    this.probe = options.probe;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  /** Subscribe to cache events. Returns an unsubscribe function. */
+  subscribe(listener: SchemaCacheListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emit(event: SchemaCacheEvent): void {
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+
+  /** Synchronously read the cached entry without probing or fetching. */
+  peek(contractId: string): ContractSchema | undefined {
+    return this.store.get(contractId);
+  }
+
+  /** Read a schema, fetching or refreshing as needed. */
+  async get(contractId: string): Promise<ContractSchema> {
+    const cached = this.store.get(contractId);
+    if (!cached) {
+      this.emit({ type: "miss", contractId });
+      return this.fetchAndStore(contractId, undefined, "missing");
+    }
+
+    const reason = this.probe ? await this.staleReason(cached) : null;
+    if (reason) {
+      return this.fetchAndStore(contractId, cached, reason);
+    }
+
+    this.emit({ type: "hit", schema: cached });
+    return cached;
+  }
+
+  private async staleReason(
+    cached: ContractSchema
+  ): Promise<"version" | "wasmHash" | null> {
+    if (!this.probe) {
+      return null;
+    }
+    const current = await this.probe.probe(cached.contractId);
+    if (current.version !== cached.version) {
+      return "version";
+    }
+    if (current.wasmHash !== cached.wasmHash) {
+      return "wasmHash";
+    }
+    return null;
+  }
+
+  /**
+   * Force a refetch and replace the cached entry. Useful from a UI on user
+   * action ("force refresh"), or when an upgrade event has been observed.
+   */
+  async refresh(contractId: string): Promise<ContractSchema> {
+    const previous = this.store.get(contractId);
+    return this.fetchAndStore(contractId, previous, "manual");
+  }
+
+  /** Drop a single contract's cached entry. */
+  invalidate(contractId: string): void {
+    if (this.store.get(contractId) !== undefined) {
+      this.store.delete(contractId);
+      this.emit({ type: "invalidated", contractId });
+    }
+  }
+
+  /** Drop every cached entry managed by this cache. */
+  clear(): void {
+    for (const key of this.store.keys()) {
+      this.invalidate(key);
+    }
+  }
+
+  private async fetchAndStore(
+    contractId: string,
+    previous: ContractSchema | undefined,
+    reason: "missing" | "version" | "wasmHash" | "manual"
+  ): Promise<ContractSchema> {
+    const fresh = await this.resolver.resolve(contractId);
+    if (fresh.contractId !== contractId) {
+      throw new Error(
+        `Resolver returned a schema for ${fresh.contractId} but ${contractId} was requested.`
+      );
+    }
+    const schema: ContractSchema = { ...fresh, fetchedAt: this.now() };
+    this.store.set(contractId, schema);
+    this.emit({ type: "refreshed", schema, previous, reason });
+    return schema;
+  }
+}
+
+/**
+ * Build a {@link SchemaResolver} from a static map of pre-known schemas
+ * (e.g. the build-time generated specs). Useful as an offline fallback or
+ * for tests.
+ */
+export function staticSchemaResolver(
+  schemas: Readonly<Record<string, Omit<ContractSchema, "fetchedAt">>>
+): SchemaResolver {
+  return {
+    async resolve(contractId: string) {
+      const schema = schemas[contractId];
+      if (!schema) {
+        throw new Error(`No static schema registered for ${contractId}.`);
+      }
+      return schema;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implements a runtime contract-schema cache for the tokenbound SDK so the client can cache a contract's full method/error spec locally and refresh it automatically when the deployed `version()` or WASM hash changes. This pairs naturally with the upgradeable contract pattern (which emits a monotonic `version()` and exposes a stable WASM hash on every upgrade).

The build-time `GENERATED_CONTRACT_SPECS` are still useful as a pinned baseline, but they go stale the moment a contract is upgraded on the network. The new `ContractSchemaCache` lets the client fetch the live spec on first use, hold it locally, and only refetch when the on-chain identity actually changes.

## Design

`sdk/src/schemaCache.ts` is a **pure module** — it does not import `@stellar/stellar-sdk`, so it is tree-shakeable and trivially testable, and consumers can plug in any resolver they like (RPC-backed, REST-backed, static snapshot, etc.).

Two-step staleness check, separated by interface:

- `SchemaIdentityProbe.probe(contractId)` — cheap call returning `{ version, wasmHash }`. Run on every cache read.
- `SchemaResolver.resolve(contractId)` — full fetch; only called when the probe reports a mismatch (or on cache miss / explicit `refresh`).

Pluggable persistence:

- `MemorySchemaStore` (default).
- `WebStorageSchemaStore` — works with `localStorage` / `sessionStorage`, scopes keys with a configurable prefix so it cannot collide with unrelated app data, and silently ignores malformed entries instead of throwing.
- `SchemaStore` is an interface, so adapters for IndexedDB, AsyncStorage, etc. are straightforward to add later.

Public surface:

- `ContractSchemaCache#get` / `peek` / `refresh` / `invalidate` / `clear`.
- `subscribe(listener)` — emits `hit` / `miss` / `refreshed` (with reason `missing` | `version` | `wasmHash` | `manual`) / `invalidated`. Useful for telemetry and "spec out of date" UI banners.
- `staticSchemaResolver(record)` — convenience for offline / pinned-spec fallbacks.

## Changes

- [x] New `sdk/src/schemaCache.ts` module (cache, store interface, two store backends, resolver/probe interfaces, helper).
- [x] Re-export from `sdk/src/index.ts` so the API is part of `@crowdpass/tokenbound-sdk`.
- [x] New `__tests__/lib/contractSchemaCache.test.ts` with 20 unit tests (see Testing).
- [x] `sdk/README.md` gains a "Caching contract schemas at runtime" section showing the recommended wiring.

## Testing

```bash
cd soroban-client
npx jest __tests__/lib/contractSchemaCache.test.ts
# → 20 passed; 0 failed

npx eslint sdk/src/schemaCache.ts __tests__/lib/contractSchemaCache.test.ts sdk/src/index.ts
# → clean

npx tsc --noEmit  # 9 errors, all pre-existing on main, none in new files
```

The 20 tests cover:

- First-fetch caching and `fetchedAt` injection.
- Probe-matched cache hit (no second resolver call).
- Refresh on `version` change.
- Refresh on `wasmHash` change.
- Behaviour without a probe (cache never auto-refreshes).
- Manual `refresh()` forces a refetch.
- `invalidate()` and `clear()` semantics.
- Event emission and `subscribe()` unsubscription contract.
- Resolver returning a mismatched `contractId` is rejected.
- Resolver errors are propagated and **not** cached as poison entries.
- `MemorySchemaStore` round-trips and `clear()`.
- `WebStorageSchemaStore` persistence, malformed JSON, missing identity fields, prefix isolation, and end-to-end recovery across cache instances.
- `staticSchemaResolver` happy and unknown-id paths.

## Notes / known limitations

- **Pre-existing test failures on `main`:** three suites fail to load on `main` due to environment issues unrelated to this change (`tokenbound-sdk.test.ts` needs a `TextEncoder` polyfill for the Stellar SDK in jsdom; `Hero.test.tsx` and `Footer.test.tsx` have Jest/Babel parse errors). The new module deliberately avoids importing `@stellar/stellar-sdk`, so the new tests run cleanly. None of these pre-existing failures are introduced by this PR.
- **Pre-existing TypeScript errors on `main`:** `app/[locale]/create-event/page.tsx` has structural JSX errors and `lib/soroban.ts` reports module-not-found. `npx tsc --noEmit` reports the same 9 errors before and after this PR — zero new errors are introduced.
- **No reference RPC resolver in this PR.** The cache is built to accept any resolver, and producing a real Soroban-RPC-backed resolver (read contract instance entry → fetch WASM → parse `contractspecv0` custom section) is a meaningful chunk of work that depends on `@stellar/stellar-sdk` types. Doing it in a follow-up keeps this PR focused and lets the cache ship usable today (with `staticSchemaResolver` for offline / generated-spec scenarios).

Closes #231