### PR TITLE
feat(ticket_nft): add name() and symbol() for ERC-20 compatibility (#195)

### DIFF
--- a/soroban-client/sdk/src/generated/contracts.ts
+++ b/soroban-client/sdk/src/generated/contracts.ts
@@ -96,7 +96,9 @@ export const GENERATED_CONTRACT_SPECS = {
       { name: "transfer_from", args: [{ name: "from", type: "Address" }, { name: "to", type: "Address" }, { name: "token_id", type: "u128" }], returns: "()", mutates: true },
       { name: "burn", args: [{ name: "token_id", type: "u128" }], returns: "()", mutates: true },
       { name: "is_valid", args: [{ name: "token_id", type: "u128" }], returns: "bool", mutates: false },
-      { name: "get_minter", args: [], returns: "Address", mutates: false }
+      { name: "get_minter", args: [], returns: "Address", mutates: false },
+      { name: "name", args: [], returns: "String", mutates: false },
+      { name: "symbol", args: [], returns: "String", mutates: false }
     ],
     errors: [
       { name: "UserAlreadyHasTicket", code: 1 },

--- a/soroban-contract/contracts/ticket_nft/src/lib.rs
+++ b/soroban-contract/contracts/ticket_nft/src/lib.rs
@@ -8,6 +8,14 @@ use soroban_sdk::{
 
 use upgradeable as upg;
 
+/// Token name returned by [`TicketNft::name`]. Static contract-level
+/// metadata; per-ticket names live in [`TicketMetadata::name`].
+pub const TOKEN_NAME: &str = "CrowdPass Ticket";
+
+/// Token symbol returned by [`TicketNft::symbol`]. Mirrors the ERC-20
+/// `symbol()` getter expected by interoperability tooling.
+pub const TOKEN_SYMBOL: &str = "TICKET";
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
@@ -318,6 +326,18 @@ impl TicketNft {
 
     pub fn is_valid(env: Env, token_id: u128) -> bool {
         env.storage().persistent().has(&DataKey::Owner(token_id))
+    }
+
+    /// ERC-20 / SEP-41 compatible token name. Returned value is constant
+    /// across the contract lifetime — per-ticket names live in
+    /// [`TicketMetadata::name`].
+    pub fn name(env: Env) -> String {
+        String::from_str(&env, TOKEN_NAME)
+    }
+
+    /// ERC-20 / SEP-41 compatible token symbol.
+    pub fn symbol(env: Env) -> String {
+        String::from_str(&env, TOKEN_SYMBOL)
     }
 
     pub fn get_minter(env: Env) -> Result<Address, Error> {

--- a/soroban-contract/contracts/ticket_nft/src/test.rs
+++ b/soroban-contract/contracts/ticket_nft/src/test.rs
@@ -143,3 +143,45 @@ fn test_update_offchain_uri_changes_token_uri() {
     let out = client.token_uri(&token_id);
     assert_eq!(out, uri);
 }
+
+#[test]
+fn test_name_returns_token_name_constant() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    assert_eq!(client.name(), String::from_str(&env, TOKEN_NAME));
+}
+
+#[test]
+fn test_symbol_returns_token_symbol_constant() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    assert_eq!(client.symbol(), String::from_str(&env, TOKEN_SYMBOL));
+}
+
+#[test]
+fn test_name_and_symbol_callable_before_any_mint() {
+    // Ensures the new getters do not depend on storage that is only
+    // populated after a mint, so off-chain tooling can introspect a freshly
+    // deployed contract.
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    assert_eq!(client.name(), String::from_str(&env, "CrowdPass Ticket"));
+    assert_eq!(client.symbol(), String::from_str(&env, "TICKET"));
+}
+
+#[test]
+fn test_name_and_symbol_unchanged_by_burn() {
+    // Contract-level metadata is independent of token lifecycle.
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    let token_id = client.mint_ticket_nft(&user);
+    let name_before = client.name();
+    let symbol_before = client.symbol();
+
+    client.burn(&token_id);
+
+    assert_eq!(client.name(), name_before);
+    assert_eq!(client.symbol(), symbol_before);
+}

--- a/soroban-contract/contracts/ticket_nft/test_snapshots/test/test_name_and_symbol_callable_before_any_mint.1.json
+++ b/soroban-contract/contracts/ticket_nft/test_snapshots/test/test_name_and_symbol_callable_before_any_mint.1.json
@@ -1,0 +1,129 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Minter"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "NextTokenId"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u128": {
+                            "hi": 0,
+                            "lo": 1
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Version"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1728000
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1728000
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/ticket_nft/test_snapshots/test/test_name_and_symbol_unchanged_by_burn.1.json
+++ b/soroban-contract/contracts/ticket_nft/test_snapshots/test/test_name_and_symbol_unchanged_by_burn.1.json
@@ -1,0 +1,286 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "function_name": "mint_ticket_nft",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "function_name": "burn",
+              "args": [
+                {
+                  "u128": {
+                    "hi": 0,
+                    "lo": 1
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u128": {
+                    "hi": 0,
+                    "lo": 0
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1728000
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Minter"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "NextTokenId"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u128": {
+                            "hi": 0,
+                            "lo": 2
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Version"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1728000
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1728000
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/ticket_nft/test_snapshots/test/test_name_returns_token_name_constant.1.json
+++ b/soroban-contract/contracts/ticket_nft/test_snapshots/test/test_name_returns_token_name_constant.1.json
@@ -1,0 +1,128 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Minter"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "NextTokenId"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u128": {
+                            "hi": 0,
+                            "lo": 1
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Version"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1728000
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1728000
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/ticket_nft/test_snapshots/test/test_symbol_returns_token_symbol_constant.1.json
+++ b/soroban-contract/contracts/ticket_nft/test_snapshots/test/test_symbol_returns_token_symbol_constant.1.json
@@ -1,0 +1,128 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Minter"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "NextTokenId"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u128": {
+                            "hi": 0,
+                            "lo": 1
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Version"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1728000
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1728000
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
## Summary

Adds `name()` and `symbol()` view functions to the `ticket_nft` Soroban contract so it satisfies the ERC-20 metadata extension and the SEP-41 token interface. Wallets, indexers, and marketplace clients that introspect token contracts via these standard getters can now read CrowdPass tickets without any special-casing.

> **Note on issue scope.** Issue #195 is missing the function names — both the title (`Implement  and  Functions for ERC-20 Compatibility`) and the body (`Add the  and  functions to the Soroban token contract…`) have empty placeholders, almost certainly due to backslash-escaping eating inline-code spans (the sibling issue #196 has the same shape). I picked the most plausible pair given the context: `name()` and `symbol()` are the standard ERC-20 metadata getters and the only universal pair currently absent from `ticket_nft`. If a different pair was intended (e.g. `approve` / `allowance`), happy to redirect — those would be a larger, separate change because allowances per `token_id` is a different model than the contract currently implements.

## Implementation

- `pub fn name(env: Env) -> String` returns the constant `"CrowdPass Ticket"`.
- `pub fn symbol(env: Env) -> String` returns the constant `"TICKET"`.
- Backed by module-level `pub const TOKEN_NAME` / `TOKEN_SYMBOL` `&str` constants, so:
  - No new storage entries (no TTL or upgrade-migration cost).
  - Callable immediately after deployment, before any mint.
  - Per-ticket display names continue to live in `TicketMetadata.name` — these new functions are **contract-level** metadata, like the equivalent ERC-20 / SEP-41 fields.
- `__constructor` signature is unchanged so `ticket_factory::deploy_ticket` and existing deployments continue to work.

## Changes

- [x] `soroban-contract/contracts/ticket_nft/src/lib.rs` — new `TOKEN_NAME` / `TOKEN_SYMBOL` constants, new `name()` / `symbol()` methods.
- [x] `soroban-contract/contracts/ticket_nft/src/test.rs` — four new unit tests.
- [x] `soroban-client/sdk/src/generated/contracts.ts` — the two new methods added to the `ticketNft` spec entry so TS consumers can call them through the SDK. (Done as a manual one-liner edit because re-running `sdk/scripts/generate-contract-types.mjs` reformats the entire 1100-line file under what looks like a different formatter version; happy to swap for a full regeneration if the maintainer prefers.)
- [x] `soroban-contract/contracts/ticket_nft/test_snapshots/...` — Soroban test snapshots committed alongside the new tests, matching the existing convention for tracked snapshots in this repo.

## Testing

```bash
cd soroban-contract
cargo test -p ticket_nft
# → 12 passed (8 existing + 4 new); 0 failed

cargo test -p ticket_factory -p marketplace -p tba_account -p tba_registry -p ticket_nft -p upgradeable
# → no regressions across all working contract crates

cargo build -p ticket_nft --target wasm32-unknown-unknown --release
# → builds clean
```

New tests:

- `test_name_returns_token_name_constant` — `name()` returns `"CrowdPass Ticket"`.
- `test_symbol_returns_token_symbol_constant` — `symbol()` returns `"TICKET"`.
- `test_name_and_symbol_callable_before_any_mint` — verifies the getters do not depend on per-ticket storage (off-chain tooling can introspect a freshly deployed contract).
- `test_name_and_symbol_unchanged_by_burn` — contract-level metadata is independent of the token lifecycle.

The pre-existing `event_manager` build/test breakage on `main` (duplicate `validate_*` definitions, missing `try_promote_from_waitlist`) is unrelated and untouched by this PR.

## Notes / known limitations

- The returned name/symbol are constants; the issue did not call for runtime-configurable metadata, and adding a setter would change the constructor signature and ripple into `ticket_factory::deploy_ticket`. If per-event branding is desired later, that's an additive follow-up (e.g. an admin-only `set_token_metadata` gated by the upgradeable admin).
- `decimals()` was deliberately not added since the issue specifies two functions and decimals on an NFT-style token is conventionally `0` and rarely consumed by interop tooling looking for `name`/`symbol` first. Easy follow-up if requested.

Closes #195