### PR TITLE
feat(soroban-contracts): Add enumerable set and map utilities for storage (#244)

### DIFF
--- a/soroban-contract/Cargo.toml
+++ b/soroban-contract/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "contracts/upgradeable",
+  "contracts/collections",
   "contracts/tba_account",
   "contracts/tba_registry",
   "contracts/ticket_nft",

--- a/soroban-contract/contracts/collections/Cargo.toml
+++ b/soroban-contract/contracts/collections/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "collections"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+upgradeable  = { path = "../upgradeable" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/soroban-contract/contracts/collections/src/enumerable_map.rs
+++ b/soroban-contract/contracts/collections/src/enumerable_map.rs
@@ -1,0 +1,233 @@
+//! Enumerable map utility for Soroban storage.
+//!
+//! # Storage layout
+//!
+//! For each (namespace, StorageTier) pair the map occupies **three** storage
+//! slots per unique key plus one Vec slot:
+//!
+//! | Key variant                  | Type     | Description                        |
+//! |------------------------------|----------|------------------------------------|
+//! | `MapKeys(namespace)`         | `Vec<K>` | Ordered list of map keys           |
+//! | `MapKeyIndex(namespace, u64)`| `u32`    | 1-based position; field is payload |
+//! | `MapValue(namespace, u64)`   | `V`      | The value for the key              |
+//!
+//! The key's `Val` raw payload (a `u64`) is used as the discriminant in both
+//! index and value storage keys, avoiding XDR limitations on `Val` fields
+//! inside `#[contracttype]` variants.
+//!
+//! # Insert / update semantics
+//!
+//! Calling `insert` with a key that already exists **updates** the stored
+//! value without changing the key order.
+//!
+//! # Removal algorithm — swap-with-last
+//!
+//! Identical to [`EnumerableSet`](super::EnumerableSet): the removed key slot
+//! is filled by the last key in the Vec, keeping all indices consistent in
+//! O(1) storage operations.
+
+use soroban_sdk::{contracttype, IntoVal, Symbol, TryFromVal, Val, Vec};
+
+use crate::storage_type::StorageTier;
+use soroban_sdk::Env;
+
+// ── Storage key types ────────────────────────────────────────────────────────
+
+/// Storage key variants for [`EnumerableMap`].
+#[contracttype]
+#[derive(Clone, Debug)]
+pub enum MapKey {
+    /// The ordered `Vec<K>` of map keys.
+    Keys(Symbol),
+    /// 1-based position of a key.  The `u64` is the key's raw `Val` payload.
+    KeyIndex(Symbol, u64),
+    /// The value stored for a key.  The `u64` is the key's raw `Val` payload.
+    Value(Symbol, u64),
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Extract the raw bit-pattern of a `Val` for use as a storage key discriminant.
+#[inline]
+fn val_payload<K: IntoVal<Env, Val>>(env: &Env, k: &K) -> u64 {
+    k.into_val(env).get_payload()
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Stateless, namespace-scoped enumerable map stored in Soroban.
+///
+/// All functions are free (not methods); the caller supplies the [`Env`],
+/// the [`StorageTier`], and a *namespace* [`Symbol`] that scopes all keys.
+pub struct EnumerableMap;
+
+impl EnumerableMap {
+    // ── Mutators ─────────────────────────────────────────────────────────────
+
+    /// Insert or update the entry `(key, value)`.
+    ///
+    /// * If `key` is **new** the key is appended to the ordered list and the
+    ///   value is written.
+    /// * If `key` **already exists** only the value is updated; key order is
+    ///   unchanged.
+    pub fn insert<K, V>(env: &Env, tier: StorageTier, ns: &Symbol, key: &K, value: &V)
+    where
+        K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
+        V: IntoVal<Env, Val>,
+    {
+        let payload = val_payload(env, key);
+        let index_key = MapKey::KeyIndex(ns.clone(), payload);
+        let value_key = MapKey::Value(ns.clone(), payload);
+
+        if !tier.has(env, &index_key) {
+            // New key — append to Vec and record its index.
+            let keys_key = MapKey::Keys(ns.clone());
+            let mut vec: Vec<K> =
+                tier.get(env, &keys_key).unwrap_or_else(|| Vec::new(env));
+            vec.push_back(key.clone());
+            let one_based = vec.len();
+            tier.set(env, &keys_key, &vec);
+            tier.set(env, &index_key, &one_based);
+        }
+
+        tier.set(env, &value_key, value);
+    }
+
+    /// Remove the entry for `key`.
+    ///
+    /// Returns `true` if the key was present (and removed), `false` if it did
+    /// not exist.
+    pub fn remove<K>(env: &Env, tier: StorageTier, ns: &Symbol, key: &K) -> bool
+    where
+        K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
+    {
+        let payload = val_payload(env, key);
+        let index_key = MapKey::KeyIndex(ns.clone(), payload);
+
+        let one_based: u32 = match tier.get(env, &index_key) {
+            Some(i) => i,
+            None => return false,
+        };
+
+        let keys_key = MapKey::Keys(ns.clone());
+        let mut vec: Vec<K> = tier.get(env, &keys_key).unwrap_or_else(|| Vec::new(env));
+
+        let zero_based = one_based - 1;
+        let last_idx = vec.len() - 1;
+
+        if zero_based != last_idx {
+            // Move the last key into the freed slot.
+            let last_key: K = vec.get(last_idx).unwrap();
+            vec.set(zero_based, last_key.clone());
+            let last_payload = val_payload(env, &last_key);
+            let last_index_key = MapKey::KeyIndex(ns.clone(), last_payload);
+            tier.set(env, &last_index_key, &one_based);
+        }
+
+        vec.pop_back();
+        tier.set(env, &keys_key, &vec);
+
+        // Delete the index and value for the removed key.
+        tier.remove(env, &index_key);
+        tier.remove(env, &MapKey::Value(ns.clone(), payload));
+
+        true
+    }
+
+    // ── Queries ──────────────────────────────────────────────────────────────
+
+    /// Returns `true` if `key` is present in the map.
+    pub fn contains_key<K>(env: &Env, tier: StorageTier, ns: &Symbol, key: &K) -> bool
+    where
+        K: IntoVal<Env, Val>,
+    {
+        let payload = val_payload(env, key);
+        tier.has(env, &MapKey::KeyIndex(ns.clone(), payload))
+    }
+
+    /// Returns the value for `key`, or `None` if not present.
+    pub fn get<K, V>(env: &Env, tier: StorageTier, ns: &Symbol, key: &K) -> Option<V>
+    where
+        K: IntoVal<Env, Val>,
+        V: TryFromVal<Env, Val>,
+    {
+        let payload = val_payload(env, key);
+        tier.get(env, &MapKey::Value(ns.clone(), payload))
+    }
+
+    /// Returns the number of entries in the map.
+    pub fn length<K>(env: &Env, tier: StorageTier, ns: &Symbol) -> u32
+    where
+        K: IntoVal<Env, Val> + TryFromVal<Env, Val>,
+    {
+        let vec: Vec<K> = tier
+            .get(env, &MapKey::Keys(ns.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+        vec.len()
+    }
+
+    /// Returns all keys in insertion order.
+    pub fn keys<K>(env: &Env, tier: StorageTier, ns: &Symbol) -> Vec<K>
+    where
+        K: IntoVal<Env, Val> + TryFromVal<Env, Val>,
+    {
+        tier.get(env, &MapKey::Keys(ns.clone()))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    /// Returns all values in key-insertion order.
+    pub fn values<K, V>(env: &Env, tier: StorageTier, ns: &Symbol) -> Vec<V>
+    where
+        K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
+        V: IntoVal<Env, Val> + TryFromVal<Env, Val>,
+    {
+        let ks: Vec<K> = Self::keys(env, tier, ns);
+        let mut result: Vec<V> = Vec::new(env);
+        for k in ks.iter() {
+            if let Some(v) = Self::get::<K, V>(env, tier, ns, &k) {
+                result.push_back(v);
+            }
+        }
+        result
+    }
+
+    /// Returns all keys and values in insertion order as two parallel `Vec`s.
+    ///
+    /// Soroban's `Vec<T>` cannot hold generic tuple types, so this function
+    /// returns `(Vec<K>, Vec<V>)` instead of `Vec<(K, V)>`.  Both vecs have
+    /// the same length and the same ordering.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let (keys, vals) = EnumerableMap::entries::<u32, i128>(&env, tier, &ns);
+    /// for i in 0..keys.len() {
+    ///     let k = keys.get(i).unwrap();
+    ///     let v = vals.get(i).unwrap();
+    /// }
+    /// ```
+    pub fn entries<K, V>(env: &Env, tier: StorageTier, ns: &Symbol) -> (Vec<K>, Vec<V>)
+    where
+        K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
+        V: IntoVal<Env, Val> + TryFromVal<Env, Val>,
+    {
+        let ks: Vec<K> = Self::keys(env, tier, ns);
+        let mut result_v: Vec<V> = Vec::new(env);
+        for k in ks.iter() {
+            if let Some(v) = Self::get::<K, V>(env, tier, ns, &k) {
+                result_v.push_back(v);
+            }
+        }
+        (ks, result_v)
+    }
+
+    /// Returns the key at 0-based `index`, or `None` if out of bounds.
+    pub fn key_at<K>(env: &Env, tier: StorageTier, ns: &Symbol, index: u32) -> Option<K>
+    where
+        K: IntoVal<Env, Val> + TryFromVal<Env, Val>,
+    {
+        let vec: Vec<K> = tier
+            .get(env, &MapKey::Keys(ns.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+        vec.get(index)
+    }
+}

--- a/soroban-contract/contracts/collections/src/enumerable_set.rs
+++ b/soroban-contract/contracts/collections/src/enumerable_set.rs
@@ -1,0 +1,175 @@
+//! Enumerable set utility for Soroban storage.
+//!
+//! # Storage layout
+//!
+//! For each (namespace, StorageTier) pair the set occupies **two** storage
+//! slots:
+//!
+//! | Key variant              | Type     | Description                        |
+//! |--------------------------|----------|------------------------------------|
+//! | `SetValues(namespace)`   | `Vec<V>` | Ordered list of members            |
+//! | `SetIndex(namespace, u64)`| `u32`   | 1-based position; key is Val payload|
+//!
+//! The member's `Val` raw payload (a `u64`) is used as the discriminant in the
+//! index key so that `Val` itself never appears inside a `#[contracttype]`
+//! variant (which would violate XDR constraints).
+//!
+//! # Removal algorithm — swap-with-last
+//!
+//! When removing element `v` at 0-based position `i`:
+//! 1. Read the last element `last` from the Vec.
+//! 2. Overwrite `vec[i]` with `last`.
+//! 3. Update `SetIndex(ns, last_payload)` to `i + 1` (1-based).
+//! 4. Pop the last slot from the Vec.
+//! 5. Delete `SetIndex(ns, v_payload)`.
+
+use soroban_sdk::{contracttype, IntoVal, Symbol, TryFromVal, Val, Vec};
+
+use crate::storage_type::StorageTier;
+use soroban_sdk::Env;
+
+// ── Storage key types ────────────────────────────────────────────────────────
+
+/// Storage key for the ordered values Vec of a named set.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub enum SetKey {
+    /// The ordered `Vec<V>` of set members.
+    Values(Symbol),
+    /// 1-based index of a member.  The second field is the member's raw `Val`
+    /// payload encoded as a `u64`, avoiding XDR limitations on `Val` fields.
+    Index(Symbol, u64),
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Extract the raw bit-pattern of a `Val` for use as a storage key discriminant.
+#[inline]
+fn val_payload<V: IntoVal<Env, Val>>(env: &Env, v: &V) -> u64 {
+    v.into_val(env).get_payload()
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Stateless, namespace-scoped enumerable set stored in Soroban.
+///
+/// All functions are free (not methods); the caller supplies the [`Env`],
+/// the [`StorageTier`], and a *namespace* [`Symbol`] that scopes all keys
+/// so multiple independent sets can live in the same contract.
+pub struct EnumerableSet;
+
+impl EnumerableSet {
+    // ── Mutators ─────────────────────────────────────────────────────────────
+
+    /// Insert `value` into the set.
+    ///
+    /// Returns `true` if the value was newly added, `false` if it already
+    /// existed (no-op).
+    pub fn insert<V>(env: &Env, tier: StorageTier, ns: &Symbol, value: &V) -> bool
+    where
+        V: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
+    {
+        let payload = val_payload(env, value);
+        let index_key = SetKey::Index(ns.clone(), payload);
+
+        // Already present — nothing to do.
+        if tier.has(env, &index_key) {
+            return false;
+        }
+
+        let values_key = SetKey::Values(ns.clone());
+        let mut vec: Vec<V> = tier.get(env, &values_key).unwrap_or_else(|| Vec::new(env));
+
+        vec.push_back(value.clone());
+        let one_based_index = vec.len(); // length after push == 1-based index of new element
+
+        tier.set(env, &values_key, &vec);
+        tier.set(env, &index_key, &one_based_index);
+
+        true
+    }
+
+    /// Remove `value` from the set using the swap-with-last algorithm.
+    ///
+    /// Returns `true` if the value was present (and removed), `false` if it
+    /// was not a member.
+    pub fn remove<V>(env: &Env, tier: StorageTier, ns: &Symbol, value: &V) -> bool
+    where
+        V: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
+    {
+        let payload = val_payload(env, value);
+        let index_key = SetKey::Index(ns.clone(), payload);
+
+        let one_based: u32 = match tier.get(env, &index_key) {
+            Some(i) => i,
+            None => return false, // not a member
+        };
+
+        let values_key = SetKey::Values(ns.clone());
+        let mut vec: Vec<V> = tier.get(env, &values_key).unwrap_or_else(|| Vec::new(env));
+
+        let zero_based = one_based - 1;
+        let last_idx = vec.len() - 1;
+
+        if zero_based != last_idx {
+            // Swap the target with the last element.
+            let last_val: V = vec.get(last_idx).unwrap();
+            vec.set(zero_based, last_val.clone());
+
+            // Update the index of the element that moved.
+            let last_payload = val_payload(env, &last_val);
+            let last_index_key = SetKey::Index(ns.clone(), last_payload);
+            tier.set(env, &last_index_key, &one_based); // it now occupies the freed slot
+        }
+
+        vec.pop_back(); // remove last (was either target or swapped copy)
+        tier.set(env, &values_key, &vec);
+        tier.remove(env, &index_key);
+
+        true
+    }
+
+    // ── Queries ──────────────────────────────────────────────────────────────
+
+    /// Returns `true` if `value` is a member of the set.
+    pub fn contains<V>(env: &Env, tier: StorageTier, ns: &Symbol, value: &V) -> bool
+    where
+        V: IntoVal<Env, Val>,
+    {
+        let payload = val_payload(env, value);
+        tier.has(env, &SetKey::Index(ns.clone(), payload))
+    }
+
+    /// Returns the number of elements in the set.
+    pub fn length<V>(env: &Env, tier: StorageTier, ns: &Symbol) -> u32
+    where
+        V: IntoVal<Env, Val> + TryFromVal<Env, Val>,
+    {
+        let vec: Vec<V> = tier
+            .get(env, &SetKey::Values(ns.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+        vec.len()
+    }
+
+    /// Returns all members as an ordered `Vec<V>`.
+    ///
+    /// Allocation is O(n); prefer using `at` for random access where possible.
+    pub fn values<V>(env: &Env, tier: StorageTier, ns: &Symbol) -> Vec<V>
+    where
+        V: IntoVal<Env, Val> + TryFromVal<Env, Val>,
+    {
+        tier.get(env, &SetKey::Values(ns.clone()))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    /// Returns the element at 0-based `index`, or `None` if out of bounds.
+    pub fn at<V>(env: &Env, tier: StorageTier, ns: &Symbol, index: u32) -> Option<V>
+    where
+        V: IntoVal<Env, Val> + TryFromVal<Env, Val>,
+    {
+        let vec: Vec<V> = tier
+            .get(env, &SetKey::Values(ns.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+        vec.get(index)
+    }
+}

--- a/soroban-contract/contracts/collections/src/lib.rs
+++ b/soroban-contract/contracts/collections/src/lib.rs
@@ -1,0 +1,60 @@
+//! # CrowdPass Enumerable Collections
+//!
+//! Optimised, enumerable storage utilities for Soroban smart contracts.
+//!
+//! ## Provided types
+//!
+//! * [`EnumerableSet`] — an ordered, deduplicated set of values backed by two storage
+//!   keys.  Insert / remove are O(1) (swap-with-last trick); iteration is O(n).
+//!
+//! * [`EnumerableMap`] — an ordered key-value map backed by three storage keys.
+//!   Insert / remove / lookup are O(1); iteration is O(n).
+//!
+//! ## Storage tiers
+//!
+//! Both utilities accept a [`StorageTier`] parameter so callers can choose the
+//! Soroban storage tier that best matches the data lifetime:
+//!
+//! | Tier         | Soroban method           | Typical use-case                  |
+//! |--------------|--------------------------|-----------------------------------|
+//! | `Instance`   | `env.storage().instance()` | Per-contract singleton state    |
+//! | `Persistent` | `env.storage().persistent()` | Long-lived per-key records    |
+//! | `Temporary`  | `env.storage().temporary()` | Short-lived / session state    |
+//!
+//! ## TTL management
+//!
+//! TTL extension is left to the **caller** (consistent with the `upgradeable`
+//! crate).  After any mutation that touches a `Persistent` or `Temporary` key
+//! you should call [`upgradeable::extend_persistent_ttl`] (or the equivalent
+//! temporary helper) on the affected namespace keys.
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use collections::{EnumerableSet, EnumerableMap, StorageTier};
+//!
+//! // --- EnumerableSet ---
+//! let ns = symbol_short!("owners");
+//! EnumerableSet::insert::<Address>(&env, StorageTier::Persistent, &ns, &alice);
+//! EnumerableSet::insert::<Address>(&env, StorageTier::Persistent, &ns, &bob);
+//! assert_eq!(EnumerableSet::length::<Address>(&env, StorageTier::Persistent, &ns), 2);
+//!
+//! // --- EnumerableMap ---
+//! let ns = symbol_short!("balances");
+//! EnumerableMap::insert::<Address, i128>(&env, StorageTier::Persistent, &ns, &alice, &100_i128);
+//! let bal = EnumerableMap::get::<Address, i128>(&env, StorageTier::Persistent, &ns, &alice);
+//! assert_eq!(bal, Some(100));
+//! ```
+
+#![no_std]
+
+pub mod enumerable_map;
+pub mod enumerable_set;
+pub mod storage_type;
+
+pub use enumerable_map::EnumerableMap;
+pub use enumerable_set::EnumerableSet;
+pub use storage_type::StorageTier;
+
+#[cfg(test)]
+mod test;

--- a/soroban-contract/contracts/collections/src/storage_type.rs
+++ b/soroban-contract/contracts/collections/src/storage_type.rs
@@ -1,0 +1,72 @@
+//! Storage tier selector used by both `EnumerableSet` and `EnumerableMap`.
+
+use soroban_sdk::{Env, IntoVal, TryFromVal, Val};
+
+/// Which Soroban storage tier to use for a collection.
+///
+/// Pass this to every [`EnumerableSet`](super::EnumerableSet) or
+/// [`EnumerableMap`](super::EnumerableMap) function.  All keys in a single
+/// collection must use the same tier.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum StorageTier {
+    /// `env.storage().instance()` — shared across the whole contract instance.
+    Instance,
+    /// `env.storage().persistent()` — survives ledger closings; TTL must be
+    /// extended explicitly.
+    Persistent,
+    /// `env.storage().temporary()` — automatically expires after the TTL
+    /// window; no rent required.
+    Temporary,
+}
+
+impl StorageTier {
+    /// Read a value from the selected storage tier.
+    pub fn get<K, V>(&self, env: &Env, key: &K) -> Option<V>
+    where
+        K: IntoVal<Env, Val>,
+        V: TryFromVal<Env, Val>,
+    {
+        match self {
+            StorageTier::Instance => env.storage().instance().get(key),
+            StorageTier::Persistent => env.storage().persistent().get(key),
+            StorageTier::Temporary => env.storage().temporary().get(key),
+        }
+    }
+
+    /// Write a value to the selected storage tier.
+    pub fn set<K, V>(&self, env: &Env, key: &K, val: &V)
+    where
+        K: IntoVal<Env, Val>,
+        V: IntoVal<Env, Val>,
+    {
+        match self {
+            StorageTier::Instance => env.storage().instance().set(key, val),
+            StorageTier::Persistent => env.storage().persistent().set(key, val),
+            StorageTier::Temporary => env.storage().temporary().set(key, val),
+        }
+    }
+
+    /// Remove a key from the selected storage tier.
+    pub fn remove<K>(&self, env: &Env, key: &K)
+    where
+        K: IntoVal<Env, Val>,
+    {
+        match self {
+            StorageTier::Instance => env.storage().instance().remove(key),
+            StorageTier::Persistent => env.storage().persistent().remove(key),
+            StorageTier::Temporary => env.storage().temporary().remove(key),
+        }
+    }
+
+    /// Check whether a key exists in the selected storage tier.
+    pub fn has<K>(&self, env: &Env, key: &K) -> bool
+    where
+        K: IntoVal<Env, Val>,
+    {
+        match self {
+            StorageTier::Instance => env.storage().instance().has(key),
+            StorageTier::Persistent => env.storage().persistent().has(key),
+            StorageTier::Temporary => env.storage().temporary().has(key),
+        }
+    }
+}

--- a/soroban-contract/contracts/collections/src/test.rs
+++ b/soroban-contract/contracts/collections/src/test.rs
@@ -1,0 +1,481 @@
+//! Unit tests for `collections` — EnumerableSet and EnumerableMap.
+//!
+//! Coverage goals:
+//! * Insert, duplicate insert (idempotent), contains, remove, re-insert
+//! * Remove-from-middle (swap-with-last correctness for both Set and Map)
+//! * EnumerableMap: insert / update / remove / get / values / entries / key_at
+//! * Empty-collection edge cases (length, values, contains, get)
+//! * Both Instance and Persistent StorageTier variants
+//!   (Temporary behaves identically to Persistent in the test env)
+//!
+//! Soroban storage can only be accessed from within a contract execution
+//! context.  All test bodies are therefore wrapped with `env.as_contract()`
+//! using a registered dummy contract.
+
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+use crate::{EnumerableMap, EnumerableSet, StorageTier};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Dummy contract — gives us a valid contract address to use with as_contract()
+// ────────────────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct DummyContract;
+
+#[contractimpl]
+impl DummyContract {}
+
+/// Register a fresh dummy contract and return (env, contract_id).
+fn setup() -> (Env, soroban_sdk::Address) {
+    let env = Env::default();
+    let id = env.register(DummyContract, ());
+    (env, id)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// EnumerableSet — Instance storage
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn set_insert_and_contains_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("owners");
+        assert!(!EnumerableSet::contains::<u32>(&env, StorageTier::Instance, &ns, &1u32));
+        assert!(EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &1u32));
+        assert!(EnumerableSet::contains::<u32>(&env, StorageTier::Instance, &ns, &1u32));
+    });
+}
+
+#[test]
+fn set_insert_duplicate_is_idempotent_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("dedup");
+        assert!(EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &42u32));
+        assert!(!EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &42u32));
+        assert_eq!(EnumerableSet::length::<u32>(&env, StorageTier::Instance, &ns), 1);
+    });
+}
+
+#[test]
+fn set_length_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("len");
+        assert_eq!(EnumerableSet::length::<u32>(&env, StorageTier::Instance, &ns), 0);
+        EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &1u32);
+        EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &2u32);
+        EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &3u32);
+        assert_eq!(EnumerableSet::length::<u32>(&env, StorageTier::Instance, &ns), 3);
+    });
+}
+
+#[test]
+fn set_values_returns_all_members_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("vals");
+        for i in 0u32..5 {
+            EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &i);
+        }
+        let v = EnumerableSet::values::<u32>(&env, StorageTier::Instance, &ns);
+        assert_eq!(v.len(), 5);
+    });
+}
+
+#[test]
+fn set_at_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("at");
+        EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &10u32);
+        EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &20u32);
+        assert_eq!(EnumerableSet::at::<u32>(&env, StorageTier::Instance, &ns, 0), Some(10u32));
+        assert_eq!(EnumerableSet::at::<u32>(&env, StorageTier::Instance, &ns, 1), Some(20u32));
+        assert_eq!(EnumerableSet::at::<u32>(&env, StorageTier::Instance, &ns, 2), None);
+    });
+}
+
+#[test]
+fn set_remove_last_element_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("rmlast");
+        EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &99u32);
+        assert!(EnumerableSet::remove::<u32>(&env, StorageTier::Instance, &ns, &99u32));
+        assert!(!EnumerableSet::contains::<u32>(&env, StorageTier::Instance, &ns, &99u32));
+        assert_eq!(EnumerableSet::length::<u32>(&env, StorageTier::Instance, &ns), 0);
+    });
+}
+
+#[test]
+fn set_remove_absent_returns_false_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("rmabs");
+        assert!(!EnumerableSet::remove::<u32>(&env, StorageTier::Instance, &ns, &7u32));
+    });
+}
+
+#[test]
+fn set_remove_middle_swap_correctness_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("rmid");
+        for i in 0u32..5 {
+            EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &i);
+        }
+        assert!(EnumerableSet::remove::<u32>(&env, StorageTier::Instance, &ns, &2u32));
+        assert_eq!(EnumerableSet::length::<u32>(&env, StorageTier::Instance, &ns), 4);
+        assert!(!EnumerableSet::contains::<u32>(&env, StorageTier::Instance, &ns, &2u32));
+        for i in [0u32, 1, 3, 4] {
+            assert!(
+                EnumerableSet::contains::<u32>(&env, StorageTier::Instance, &ns, &i),
+                "value {i} should still be in the set"
+            );
+        }
+    });
+}
+
+#[test]
+fn set_remove_and_reinsert_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("reins");
+        EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &5u32);
+        assert!(EnumerableSet::remove::<u32>(&env, StorageTier::Instance, &ns, &5u32));
+        assert!(EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &5u32));
+        assert!(EnumerableSet::contains::<u32>(&env, StorageTier::Instance, &ns, &5u32));
+        assert_eq!(EnumerableSet::length::<u32>(&env, StorageTier::Instance, &ns), 1);
+    });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// EnumerableSet — Persistent storage
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn set_insert_and_contains_persistent() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("powners");
+        assert!(EnumerableSet::insert::<u32>(&env, StorageTier::Persistent, &ns, &1u32));
+        assert!(EnumerableSet::contains::<u32>(&env, StorageTier::Persistent, &ns, &1u32));
+        assert!(!EnumerableSet::contains::<u32>(&env, StorageTier::Persistent, &ns, &2u32));
+    });
+}
+
+#[test]
+fn set_remove_middle_persistent() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("prmid");
+        for i in 0u32..4 {
+            EnumerableSet::insert::<u32>(&env, StorageTier::Persistent, &ns, &i);
+        }
+        assert!(EnumerableSet::remove::<u32>(&env, StorageTier::Persistent, &ns, &1u32));
+        assert_eq!(EnumerableSet::length::<u32>(&env, StorageTier::Persistent, &ns), 3);
+        assert!(!EnumerableSet::contains::<u32>(&env, StorageTier::Persistent, &ns, &1u32));
+        for i in [0u32, 2, 3] {
+            assert!(EnumerableSet::contains::<u32>(&env, StorageTier::Persistent, &ns, &i));
+        }
+    });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// EnumerableSet — Temporary storage
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn set_insert_and_remove_temporary() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("tmp");
+        assert!(EnumerableSet::insert::<u32>(&env, StorageTier::Temporary, &ns, &77u32));
+        assert!(EnumerableSet::contains::<u32>(&env, StorageTier::Temporary, &ns, &77u32));
+        assert!(EnumerableSet::remove::<u32>(&env, StorageTier::Temporary, &ns, &77u32));
+        assert!(!EnumerableSet::contains::<u32>(&env, StorageTier::Temporary, &ns, &77u32));
+    });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// EnumerableSet — namespace isolation
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn set_namespaces_are_isolated() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns_a = symbol_short!("nsA");
+        let ns_b = symbol_short!("nsB");
+        EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns_a, &1u32);
+        assert!(EnumerableSet::contains::<u32>(&env, StorageTier::Instance, &ns_a, &1u32));
+        assert!(!EnumerableSet::contains::<u32>(&env, StorageTier::Instance, &ns_b, &1u32));
+        assert_eq!(EnumerableSet::length::<u32>(&env, StorageTier::Instance, &ns_b), 0);
+    });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// EnumerableMap — Instance storage
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn map_insert_and_get_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("balances");
+        assert!(!EnumerableMap::contains_key::<u32>(&env, StorageTier::Instance, &ns, &1u32));
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &1u32, &100i128);
+        assert!(EnumerableMap::contains_key::<u32>(&env, StorageTier::Instance, &ns, &1u32));
+        assert_eq!(
+            EnumerableMap::get::<u32, i128>(&env, StorageTier::Instance, &ns, &1u32),
+            Some(100i128)
+        );
+    });
+}
+
+#[test]
+fn map_insert_update_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("balu");
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &1u32, &50i128);
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &1u32, &200i128);
+        assert_eq!(EnumerableMap::length::<u32>(&env, StorageTier::Instance, &ns), 1);
+        assert_eq!(
+            EnumerableMap::get::<u32, i128>(&env, StorageTier::Instance, &ns, &1u32),
+            Some(200i128)
+        );
+    });
+}
+
+#[test]
+fn map_get_missing_returns_none_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("none");
+        assert_eq!(
+            EnumerableMap::get::<u32, i128>(&env, StorageTier::Instance, &ns, &99u32),
+            None
+        );
+    });
+}
+
+#[test]
+fn map_length_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("maplen");
+        assert_eq!(EnumerableMap::length::<u32>(&env, StorageTier::Instance, &ns), 0);
+        for i in 0u32..3 {
+            EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &i, &(i as i128 * 10));
+        }
+        assert_eq!(EnumerableMap::length::<u32>(&env, StorageTier::Instance, &ns), 3);
+    });
+}
+
+#[test]
+fn map_keys_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("mapkeys");
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &10u32, &1i128);
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &20u32, &2i128);
+        let keys = EnumerableMap::keys::<u32>(&env, StorageTier::Instance, &ns);
+        assert_eq!(keys.len(), 2);
+        assert_eq!(keys.get(0), Some(10u32));
+        assert_eq!(keys.get(1), Some(20u32));
+    });
+}
+
+#[test]
+fn map_values_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("mapvals");
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &1u32, &11i128);
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &2u32, &22i128);
+        let vals = EnumerableMap::values::<u32, i128>(&env, StorageTier::Instance, &ns);
+        assert_eq!(vals.len(), 2);
+        assert_eq!(vals.get(0), Some(11i128));
+        assert_eq!(vals.get(1), Some(22i128));
+    });
+}
+
+#[test]
+fn map_entries_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("entries");
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &1u32, &100i128);
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &2u32, &200i128);
+        let (keys, vals) = EnumerableMap::entries::<u32, i128>(&env, StorageTier::Instance, &ns);
+        assert_eq!(keys.len(), 2);
+        assert_eq!(vals.len(), 2);
+        assert_eq!(keys.get(0), Some(1u32));
+        assert_eq!(vals.get(0), Some(100i128));
+        assert_eq!(keys.get(1), Some(2u32));
+        assert_eq!(vals.get(1), Some(200i128));
+    });
+}
+
+#[test]
+fn map_key_at_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("keyat");
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &7u32, &70i128);
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &8u32, &80i128);
+        assert_eq!(EnumerableMap::key_at::<u32>(&env, StorageTier::Instance, &ns, 0), Some(7u32));
+        assert_eq!(EnumerableMap::key_at::<u32>(&env, StorageTier::Instance, &ns, 1), Some(8u32));
+        assert_eq!(EnumerableMap::key_at::<u32>(&env, StorageTier::Instance, &ns, 2), None);
+    });
+}
+
+#[test]
+fn map_remove_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("maprm");
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &1u32, &10i128);
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &2u32, &20i128);
+        assert!(EnumerableMap::remove::<u32>(&env, StorageTier::Instance, &ns, &1u32));
+        assert!(!EnumerableMap::contains_key::<u32>(&env, StorageTier::Instance, &ns, &1u32));
+        assert_eq!(EnumerableMap::get::<u32, i128>(&env, StorageTier::Instance, &ns, &1u32), None);
+        assert_eq!(EnumerableMap::length::<u32>(&env, StorageTier::Instance, &ns), 1);
+        assert_eq!(
+            EnumerableMap::get::<u32, i128>(&env, StorageTier::Instance, &ns, &2u32),
+            Some(20i128)
+        );
+    });
+}
+
+#[test]
+fn map_remove_absent_returns_false_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("rmabs2");
+        assert!(!EnumerableMap::remove::<u32>(&env, StorageTier::Instance, &ns, &99u32));
+    });
+}
+
+#[test]
+fn map_remove_middle_swap_correctness_instance() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("mmid");
+        for i in 0u32..5 {
+            EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns, &i, &(i as i128 * 10));
+        }
+        assert!(EnumerableMap::remove::<u32>(&env, StorageTier::Instance, &ns, &2u32));
+        assert_eq!(EnumerableMap::length::<u32>(&env, StorageTier::Instance, &ns), 4);
+        assert!(!EnumerableMap::contains_key::<u32>(&env, StorageTier::Instance, &ns, &2u32));
+        assert_eq!(EnumerableMap::get::<u32, i128>(&env, StorageTier::Instance, &ns, &2u32), None);
+        for i in [0u32, 1, 3, 4] {
+            assert!(EnumerableMap::contains_key::<u32>(&env, StorageTier::Instance, &ns, &i));
+            assert_eq!(
+                EnumerableMap::get::<u32, i128>(&env, StorageTier::Instance, &ns, &i),
+                Some(i as i128 * 10)
+            );
+        }
+    });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// EnumerableMap — Persistent storage
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn map_insert_and_remove_persistent() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("pmap");
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Persistent, &ns, &5u32, &55i128);
+        assert_eq!(
+            EnumerableMap::get::<u32, i128>(&env, StorageTier::Persistent, &ns, &5u32),
+            Some(55i128)
+        );
+        assert!(EnumerableMap::remove::<u32>(&env, StorageTier::Persistent, &ns, &5u32));
+        assert_eq!(
+            EnumerableMap::get::<u32, i128>(&env, StorageTier::Persistent, &ns, &5u32),
+            None
+        );
+    });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// EnumerableMap — namespace isolation
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn map_namespaces_are_isolated() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns_a = symbol_short!("mnsA");
+        let ns_b = symbol_short!("mnsB");
+        EnumerableMap::insert::<u32, i128>(&env, StorageTier::Instance, &ns_a, &1u32, &999i128);
+        assert!(EnumerableMap::contains_key::<u32>(&env, StorageTier::Instance, &ns_a, &1u32));
+        assert!(!EnumerableMap::contains_key::<u32>(&env, StorageTier::Instance, &ns_b, &1u32));
+        assert_eq!(EnumerableMap::length::<u32>(&env, StorageTier::Instance, &ns_b), 0);
+    });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Edge cases — empty collections
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn set_empty_collection_queries() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("empty");
+        assert_eq!(EnumerableSet::length::<u32>(&env, StorageTier::Instance, &ns), 0);
+        assert_eq!(EnumerableSet::values::<u32>(&env, StorageTier::Instance, &ns).len(), 0);
+        assert!(!EnumerableSet::contains::<u32>(&env, StorageTier::Instance, &ns, &1u32));
+        assert_eq!(EnumerableSet::at::<u32>(&env, StorageTier::Instance, &ns, 0), None);
+        assert!(!EnumerableSet::remove::<u32>(&env, StorageTier::Instance, &ns, &1u32));
+    });
+}
+
+#[test]
+fn map_empty_collection_queries() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("emptyM");
+        assert_eq!(EnumerableMap::length::<u32>(&env, StorageTier::Instance, &ns), 0);
+        assert_eq!(EnumerableMap::keys::<u32>(&env, StorageTier::Instance, &ns).len(), 0);
+        assert_eq!(EnumerableMap::values::<u32, i128>(&env, StorageTier::Instance, &ns).len(), 0);
+        assert_eq!(EnumerableMap::entries::<u32, i128>(&env, StorageTier::Instance, &ns).0.len(), 0);
+        assert!(!EnumerableMap::contains_key::<u32>(&env, StorageTier::Instance, &ns, &1u32));
+        assert_eq!(EnumerableMap::get::<u32, i128>(&env, StorageTier::Instance, &ns, &1u32), None);
+        assert_eq!(EnumerableMap::key_at::<u32>(&env, StorageTier::Instance, &ns, 0), None);
+        assert!(!EnumerableMap::remove::<u32>(&env, StorageTier::Instance, &ns, &1u32));
+    });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Large-set remove stress (swap-with-last consistency)
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn set_remove_all_elements_one_by_one() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        let ns = symbol_short!("rmall");
+        let n = 10u32;
+        for i in 0..n {
+            EnumerableSet::insert::<u32>(&env, StorageTier::Instance, &ns, &i);
+        }
+        // Remove in an order that exercises different swap paths
+        for i in [0u32, 5, 9, 1, 4, 2, 8, 3, 7, 6] {
+            assert!(EnumerableSet::remove::<u32>(&env, StorageTier::Instance, &ns, &i));
+        }
+        assert_eq!(EnumerableSet::length::<u32>(&env, StorageTier::Instance, &ns), 0);
+    });
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_empty_collection_queries.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_empty_collection_queries.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_entries_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_entries_instance.1.json
@@ -1,0 +1,177 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "entries"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "entries"
+                            },
+                            {
+                              "u64": 8589934596
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Keys"
+                            },
+                            {
+                              "symbol": "entries"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "entries"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "entries"
+                            },
+                            {
+                              "u64": 8589934596
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 200
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_get_missing_returns_none_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_get_missing_returns_none_instance.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_insert_and_get_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_insert_and_get_instance.1.json
@@ -1,0 +1,135 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "balances"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Keys"
+                            },
+                            {
+                              "symbol": "balances"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "balances"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_insert_and_remove_persistent.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_insert_and_remove_persistent.1.json
@@ -1,0 +1,121 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Keys"
+                },
+                {
+                  "symbol": "pmap"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Keys"
+                    },
+                    {
+                      "symbol": "pmap"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_insert_update_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_insert_update_instance.1.json
@@ -1,0 +1,135 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "balu"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Keys"
+                            },
+                            {
+                              "symbol": "balu"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "balu"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 200
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_key_at_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_key_at_instance.1.json
@@ -1,0 +1,177 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "keyat"
+                            },
+                            {
+                              "u64": 30064771076
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "keyat"
+                            },
+                            {
+                              "u64": 34359738372
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Keys"
+                            },
+                            {
+                              "symbol": "keyat"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 7
+                            },
+                            {
+                              "u32": 8
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "keyat"
+                            },
+                            {
+                              "u64": 30064771076
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 70
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "keyat"
+                            },
+                            {
+                              "u64": 34359738372
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 80
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_keys_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_keys_instance.1.json
@@ -1,0 +1,177 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "mapkeys"
+                            },
+                            {
+                              "u64": 42949672964
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "mapkeys"
+                            },
+                            {
+                              "u64": 85899345924
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Keys"
+                            },
+                            {
+                              "symbol": "mapkeys"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 10
+                            },
+                            {
+                              "u32": 20
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "mapkeys"
+                            },
+                            {
+                              "u64": 42949672964
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "mapkeys"
+                            },
+                            {
+                              "u64": 85899345924
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 2
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_length_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_length_instance.1.json
@@ -1,0 +1,219 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "maplen"
+                            },
+                            {
+                              "u64": 4
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "maplen"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "maplen"
+                            },
+                            {
+                              "u64": 8589934596
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 3
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Keys"
+                            },
+                            {
+                              "symbol": "maplen"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 0
+                            },
+                            {
+                              "u32": 1
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "maplen"
+                            },
+                            {
+                              "u64": 4
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "maplen"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 10
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "maplen"
+                            },
+                            {
+                              "u64": 8589934596
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 20
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_namespaces_are_isolated.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_namespaces_are_isolated.1.json
@@ -1,0 +1,135 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "mnsA"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Keys"
+                            },
+                            {
+                              "symbol": "mnsA"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "mnsA"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 999
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_remove_absent_returns_false_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_remove_absent_returns_false_instance.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_remove_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_remove_instance.1.json
@@ -1,0 +1,135 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "maprm"
+                            },
+                            {
+                              "u64": 8589934596
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Keys"
+                            },
+                            {
+                              "symbol": "maprm"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "maprm"
+                            },
+                            {
+                              "u64": 8589934596
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 20
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_remove_middle_swap_correctness_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_remove_middle_swap_correctness_instance.1.json
@@ -1,0 +1,261 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "mmid"
+                            },
+                            {
+                              "u64": 4
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "mmid"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "mmid"
+                            },
+                            {
+                              "u64": 12884901892
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 4
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "mmid"
+                            },
+                            {
+                              "u64": 17179869188
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 3
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Keys"
+                            },
+                            {
+                              "symbol": "mmid"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 0
+                            },
+                            {
+                              "u32": 1
+                            },
+                            {
+                              "u32": 4
+                            },
+                            {
+                              "u32": 3
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "mmid"
+                            },
+                            {
+                              "u64": 4
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "mmid"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 10
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "mmid"
+                            },
+                            {
+                              "u64": 12884901892
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 30
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "mmid"
+                            },
+                            {
+                              "u64": 17179869188
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 40
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_values_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_values_instance.1.json
@@ -1,0 +1,177 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "mapvals"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "KeyIndex"
+                            },
+                            {
+                              "symbol": "mapvals"
+                            },
+                            {
+                              "u64": 8589934596
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Keys"
+                            },
+                            {
+                              "symbol": "mapvals"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "mapvals"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 11
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Value"
+                            },
+                            {
+                              "symbol": "mapvals"
+                            },
+                            {
+                              "u64": 8589934596
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 22
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_at_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_at_instance.1.json
@@ -1,0 +1,135 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "at"
+                            },
+                            {
+                              "u64": 42949672964
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "at"
+                            },
+                            {
+                              "u64": 85899345924
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Values"
+                            },
+                            {
+                              "symbol": "at"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 10
+                            },
+                            {
+                              "u32": 20
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_empty_collection_queries.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_empty_collection_queries.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_contains_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_contains_instance.1.json
@@ -1,0 +1,114 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "owners"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Values"
+                            },
+                            {
+                              "symbol": "owners"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_contains_persistent.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_contains_persistent.1.json
@@ -1,0 +1,176 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Index"
+                },
+                {
+                  "symbol": "powners"
+                },
+                {
+                  "u64": 4294967300
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Index"
+                    },
+                    {
+                      "symbol": "powners"
+                    },
+                    {
+                      "u64": 4294967300
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Values"
+                },
+                {
+                  "symbol": "powners"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Values"
+                    },
+                    {
+                      "symbol": "powners"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "u32": 1
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_remove_temporary.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_remove_temporary.1.json
@@ -1,0 +1,121 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Values"
+                },
+                {
+                  "symbol": "tmp"
+                }
+              ]
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Values"
+                    },
+                    {
+                      "symbol": "tmp"
+                    }
+                  ]
+                },
+                "durability": "temporary",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          15
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_insert_duplicate_is_idempotent_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_insert_duplicate_is_idempotent_instance.1.json
@@ -1,0 +1,114 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "dedup"
+                            },
+                            {
+                              "u64": 180388626436
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Values"
+                            },
+                            {
+                              "symbol": "dedup"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 42
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_length_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_length_instance.1.json
@@ -1,0 +1,156 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "len"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "len"
+                            },
+                            {
+                              "u64": 8589934596
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "len"
+                            },
+                            {
+                              "u64": 12884901892
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 3
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Values"
+                            },
+                            {
+                              "symbol": "len"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
+                            },
+                            {
+                              "u32": 2
+                            },
+                            {
+                              "u32": 3
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_namespaces_are_isolated.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_namespaces_are_isolated.1.json
@@ -1,0 +1,114 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "nsA"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Values"
+                            },
+                            {
+                              "symbol": "nsA"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_remove_absent_returns_false_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_remove_absent_returns_false_instance.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_remove_all_elements_one_by_one.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_remove_all_elements_one_by_one.1.json
@@ -1,0 +1,92 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Values"
+                            },
+                            {
+                              "symbol": "rmall"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": []
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_remove_and_reinsert_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_remove_and_reinsert_instance.1.json
@@ -1,0 +1,114 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "reins"
+                            },
+                            {
+                              "u64": 21474836484
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Values"
+                            },
+                            {
+                              "symbol": "reins"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 5
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_remove_last_element_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_remove_last_element_instance.1.json
@@ -1,0 +1,92 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Values"
+                            },
+                            {
+                              "symbol": "rmlast"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": []
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_remove_middle_persistent.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_remove_middle_persistent.1.json
@@ -1,0 +1,284 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Index"
+                },
+                {
+                  "symbol": "prmid"
+                },
+                {
+                  "u64": 4
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Index"
+                    },
+                    {
+                      "symbol": "prmid"
+                    },
+                    {
+                      "u64": 4
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Index"
+                },
+                {
+                  "symbol": "prmid"
+                },
+                {
+                  "u64": 8589934596
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Index"
+                    },
+                    {
+                      "symbol": "prmid"
+                    },
+                    {
+                      "u64": 8589934596
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 3
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Index"
+                },
+                {
+                  "symbol": "prmid"
+                },
+                {
+                  "u64": 12884901892
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Index"
+                    },
+                    {
+                      "symbol": "prmid"
+                    },
+                    {
+                      "u64": 12884901892
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Values"
+                },
+                {
+                  "symbol": "prmid"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Values"
+                    },
+                    {
+                      "symbol": "prmid"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "u32": 0
+                    },
+                    {
+                      "u32": 3
+                    },
+                    {
+                      "u32": 2
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_remove_middle_swap_correctness_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_remove_middle_swap_correctness_instance.1.json
@@ -1,0 +1,177 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "rmid"
+                            },
+                            {
+                              "u64": 4
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "rmid"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "rmid"
+                            },
+                            {
+                              "u64": 12884901892
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 4
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "rmid"
+                            },
+                            {
+                              "u64": 17179869188
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 3
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Values"
+                            },
+                            {
+                              "symbol": "rmid"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 0
+                            },
+                            {
+                              "u32": 1
+                            },
+                            {
+                              "u32": 4
+                            },
+                            {
+                              "u32": 3
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_values_returns_all_members_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_values_returns_all_members_instance.1.json
@@ -1,0 +1,198 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "vals"
+                            },
+                            {
+                              "u64": 4
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "vals"
+                            },
+                            {
+                              "u64": 4294967300
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "vals"
+                            },
+                            {
+                              "u64": 8589934596
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 3
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "vals"
+                            },
+                            {
+                              "u64": 12884901892
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 4
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Index"
+                            },
+                            {
+                              "symbol": "vals"
+                            },
+                            {
+                              "u64": 17179869188
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 5
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Values"
+                            },
+                            {
+                              "symbol": "vals"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 0
+                            },
+                            {
+                              "u32": 1
+                            },
+                            {
+                              "u32": 2
+                            },
+                            {
+                              "u32": 3
+                            },
+                            {
+                              "u32": 4
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
## Summary

Closes #244

Adds a new shared `collections` crate to the `soroban-contract` workspace, providing optimised, enumerable collection abstractions for common contract state patterns — a direct replacement for the hand-rolled linear-scan patterns currently found across the marketplace, registry, and factory contracts.

---

## New crate: `contracts/collections`

### `EnumerableSet<V>`
An ordered, deduplicated set backed by two storage keys per namespace.

| Operation | Complexity |
|---|---|
| `insert` | O(1) |
| `remove` | O(1) — swap-with-last |
| `contains` | O(1) |
| `values` / `length` / `at` | O(n) / O(1) / O(1) |

### `EnumerableMap<K, V>`
An ordered key-value map backed by three storage keys per namespace.

| Operation | Complexity |
|---|---|
| `insert` / `update` | O(1) |
| `remove` | O(1) — swap-with-last |
| `get` / `contains_key` | O(1) |
| `keys` / `values` / `entries` / `key_at` | O(n) |

### `StorageTier` enum
Both collections accept a `StorageTier` (Instance / Persistent / Temporary) so the same functions work across all three Soroban storage tiers with no code duplication.

---

## Key design decisions

- **Swap-with-last removal**: When removing element at position `i`, the last element is moved into slot `i` and the index side-table updated — O(1) with no gaps.
- **`Val` payload as `u64` discriminant**: Soroban's `#[contracttype]` macro cannot serialize `Val` directly in enum variants (XDR constraint). The raw 64-bit payload from `val.get_payload()` is stored as `u64` instead — safe for all primitive and SDK types.
- **`entries()` returns `(Vec<K>, Vec<V>)`**: Soroban's `Vec<(K,V)>` lacks generic blanket impls for tuple types. Returning two parallel vecs avoids the constraint while preserving the same data.
- **TTL left to caller**: Consistent with the `upgradeable` crate — no hidden side-effects. Call `upgradeable::extend_persistent_ttl()` after mutations as needed.
- **Zero breaking changes**: Purely additive. No existing contracts are modified.

---

## Files changed

| File | Change |
|---|---|
| `soroban-contract/Cargo.toml` | Added `contracts/collections` to workspace members |
| `contracts/collections/Cargo.toml` | New `rlib` crate |
| `contracts/collections/src/lib.rs` | Module root + public re-exports |
| `contracts/collections/src/storage_type.rs` | `StorageTier` dispatcher |
| `contracts/collections/src/enumerable_set.rs` | `EnumerableSet` implementation |
| `contracts/collections/src/enumerable_map.rs` | `EnumerableMap` implementation |
| `contracts/collections/src/test.rs` | 29 unit tests |

---

## Test results

running 29 tests test test::map_empty_collection_queries ... ok test test::map_entries_instance ... ok test test::map_get_missing_returns_none_instance ... ok test test::map_insert_and_get_instance ... ok test test::map_insert_and_remove_persistent ... ok test test::map_insert_update_instance ... ok test test::map_key_at_instance ... ok test test::map_keys_instance ... ok test test::map_length_instance ... ok test test::map_namespaces_are_isolated ... ok test test::map_remove_absent_returns_false_instance ... ok test test::map_remove_instance ... ok test test::map_remove_middle_swap_correctness_instance ... ok test test::map_values_instance ... ok test test::set_at_instance ... ok test test::set_empty_collection_queries ... ok test test::set_insert_and_contains_instance ... ok test test::set_insert_and_contains_persistent ... ok test test::set_insert_and_remove_temporary ... ok test test::set_insert_duplicate_is_idempotent_instance ... ok test test::set_length_instance ... ok test test::set_namespaces_are_isolated ... ok test test::set_remove_absent_returns_false_instance ... ok test test::set_remove_all_elements_one_by_one ... ok test test::set_remove_and_reinsert_instance ... ok test test::set_remove_last_element_instance ... ok test test::set_remove_middle_persistent ... ok test test::set_remove_middle_swap_correctness_instance ... ok test test::set_values_returns_all_members_instance ... ok

test result: ok. 29 passed; 0 failed; 0 ignored

---
## Checklist
- [x] New `collections` crate compiles clean
- [x] 29/29 unit tests pass (`cargo test -p collections`)
- [x] All existing contracts still compile (`cargo build -p upgradeable -p tba_account -p tba_registry -p ticket_nft -p ticket_factory -p marketplace -p collections`)
- [x] Zero breaking changes to existing contracts
- [x] Follows `upgradeable` crate conventions (TTL left to caller, no hidden side-effects)