### PR TITLE
feat(soroban-client): batch ledger entry fetch helper (#222)

### DIFF
--- a/soroban-client/__tests__/lib/batchLedgerEntries.test.ts
+++ b/soroban-client/__tests__/lib/batchLedgerEntries.test.ts
@@ -1,0 +1,323 @@
+import {
+  DEFAULT_BATCH_CHUNK_SIZE,
+  batchGetLedgerEntries,
+  type BatchLedgerEntriesOptions,
+  type LedgerEntriesFetcher,
+} from "@/sdk/src/batchLedgerEntries";
+
+// We import only types from stellar-sdk in the helper, and tests never need
+// the real LedgerKey type — the helper takes a structural `keyId` callback
+// so we model keys as plain strings here.
+type FakeKey = string;
+
+interface FakeLedgerEntryResult {
+  readonly key: FakeKey;
+  readonly val: unknown;
+  readonly liveUntilLedgerSeq?: number;
+}
+
+interface FakeBatchResponse {
+  readonly entries: FakeLedgerEntryResult[];
+  readonly latestLedger: number;
+}
+
+function buildFetcher(
+  handler: (keys: FakeKey[]) => Promise<FakeBatchResponse> | FakeBatchResponse
+): LedgerEntriesFetcher & { calls: FakeKey[][] } {
+  const calls: FakeKey[][] = [];
+  const fetcher = {
+    calls,
+    async getLedgerEntries(...keys: unknown[]) {
+      calls.push(keys as FakeKey[]);
+      const response = await handler(keys as FakeKey[]);
+      return response as never;
+    },
+  };
+  return fetcher as LedgerEntriesFetcher & { calls: FakeKey[][] };
+}
+
+const baseOptions = (): BatchLedgerEntriesOptions => ({
+  // Casting through `unknown` because the helper's signature uses the
+  // real xdr.LedgerKey type but our tests use plain strings.
+  keyId: (key) => key as unknown as string,
+});
+
+describe("batchGetLedgerEntries", () => {
+  it("returns immediately for an empty key list without calling the RPC", async () => {
+    const fetcher = buildFetcher(() => {
+      throw new Error("RPC should not be called for empty input");
+    });
+
+    const result = await batchGetLedgerEntries(fetcher, [], baseOptions());
+
+    expect(result).toEqual({
+      entries: [],
+      errors: [],
+      latestLedger: 0,
+      found: 0,
+      missing: 0,
+      failed: 0,
+    });
+    expect(fetcher.calls).toEqual([]);
+  });
+
+  it("fans out a single chunk when input fits within the chunk size", async () => {
+    const fetcher = buildFetcher((keys) => ({
+      entries: keys.map((key) => ({ key, val: `val:${key}` })),
+      latestLedger: 42,
+    }));
+
+    const result = await batchGetLedgerEntries(
+      fetcher,
+      ["a", "b", "c"] as never,
+      baseOptions()
+    );
+
+    expect(fetcher.calls).toEqual([["a", "b", "c"]]);
+    expect(result.entries).toEqual([
+      { key: "a", val: "val:a" },
+      { key: "b", val: "val:b" },
+      { key: "c", val: "val:c" },
+    ]);
+    expect(result.latestLedger).toBe(42);
+    expect(result.found).toBe(3);
+    expect(result.missing).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it("chunks oversized inputs into multiple RPC calls", async () => {
+    const keys = Array.from({ length: 7 }, (_, index) => `k${index}`);
+    const fetcher = buildFetcher((chunkKeys) => ({
+      entries: chunkKeys.map((key) => ({ key, val: key.toUpperCase() })),
+      latestLedger: 100,
+    }));
+
+    const result = await batchGetLedgerEntries(fetcher, keys as never, {
+      ...baseOptions(),
+      chunkSize: 3,
+    });
+
+    expect(fetcher.calls).toEqual([
+      ["k0", "k1", "k2"],
+      ["k3", "k4", "k5"],
+      ["k6"],
+    ]);
+    expect(result.entries.map((entry) => (entry ? entry.val : entry))).toEqual([
+      "K0",
+      "K1",
+      "K2",
+      "K3",
+      "K4",
+      "K5",
+      "K6",
+    ]);
+    expect(result.found).toBe(7);
+  });
+
+  it("aligns missing entries to null while preserving input order", async () => {
+    // RPC returns only the entries that exist; the helper must back-fill
+    // null at the corresponding input positions.
+    const fetcher = buildFetcher((keys) => ({
+      entries: keys
+        .filter((key) => key !== "missing-1" && key !== "missing-2")
+        .map((key) => ({ key, val: key })),
+      latestLedger: 7,
+    }));
+
+    const result = await batchGetLedgerEntries(
+      fetcher,
+      ["a", "missing-1", "b", "missing-2", "c"] as never,
+      baseOptions()
+    );
+
+    expect(result.entries).toEqual([
+      { key: "a", val: "a" },
+      null,
+      { key: "b", val: "b" },
+      null,
+      { key: "c", val: "c" },
+    ]);
+    expect(result.found).toBe(3);
+    expect(result.missing).toBe(2);
+    expect(result.failed).toBe(0);
+  });
+
+  it("records partial-failure chunk errors and keeps successful chunk data", async () => {
+    let callIndex = 0;
+    const fetcher = buildFetcher((keys) => {
+      callIndex += 1;
+      if (callIndex === 2) {
+        throw new Error("rpc 5xx");
+      }
+      return {
+        entries: keys.map((key) => ({ key, val: key })),
+        latestLedger: 99,
+      };
+    });
+
+    const result = await batchGetLedgerEntries(
+      fetcher,
+      ["a", "b", "c", "d"] as never,
+      { ...baseOptions(), chunkSize: 2, concurrency: 1 }
+    );
+
+    expect(result.entries).toEqual([
+      { key: "a", val: "a" },
+      { key: "b", val: "b" },
+      undefined, // chunk 2 failed
+      undefined,
+    ]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].indexes).toEqual([2, 3]);
+    expect((result.errors[0].error as Error).message).toBe("rpc 5xx");
+    expect(result.found).toBe(2);
+    expect(result.missing).toBe(0);
+    expect(result.failed).toBe(2);
+    expect(result.latestLedger).toBe(99);
+  });
+
+  it("uses the latest 'latestLedger' across successful chunks", async () => {
+    const ledgers = [10, 30, 20];
+    let chunkIdx = 0;
+    const fetcher = buildFetcher((keys) => {
+      const latestLedger = ledgers[chunkIdx];
+      chunkIdx += 1;
+      return {
+        entries: keys.map((key) => ({ key, val: key })),
+        latestLedger,
+      };
+    });
+
+    const result = await batchGetLedgerEntries(
+      fetcher,
+      ["a", "b", "c"] as never,
+      { ...baseOptions(), chunkSize: 1, concurrency: 1 }
+    );
+
+    expect(result.latestLedger).toBe(30);
+  });
+
+  it("returns latestLedger=0 when every chunk fails", async () => {
+    const fetcher = buildFetcher(() => {
+      throw new Error("network down");
+    });
+
+    const result = await batchGetLedgerEntries(
+      fetcher,
+      ["a", "b"] as never,
+      { ...baseOptions(), chunkSize: 1, concurrency: 1 }
+    );
+
+    expect(result.latestLedger).toBe(0);
+    expect(result.failed).toBe(2);
+    expect(result.errors).toHaveLength(2);
+  });
+
+  it("deduplicates duplicate input keys without a second RPC trip per duplicate", async () => {
+    // Two duplicate input keys still send one RPC roundtrip per *occurrence*
+    // (because we don't dedupe the request itself), but both indexes must
+    // receive the entry the RPC returned for the shared identity.
+    const fetcher = buildFetcher((keys) => {
+      // RPC returns only one entry for "x" even though the request has two.
+      const unique = Array.from(new Set(keys));
+      return {
+        entries: unique.map((key) => ({ key, val: key })),
+        latestLedger: 1,
+      };
+    });
+
+    const result = await batchGetLedgerEntries(
+      fetcher,
+      ["x", "y", "x"] as never,
+      baseOptions()
+    );
+
+    expect(result.entries).toEqual([
+      { key: "x", val: "x" },
+      { key: "y", val: "y" },
+      { key: "x", val: "x" },
+    ]);
+    expect(result.found).toBe(3);
+  });
+
+  it("ignores response entries whose key was not requested", async () => {
+    const fetcher = buildFetcher(() => ({
+      entries: [
+        { key: "a", val: "a" },
+        { key: "stranger", val: "?" }, // not in the input
+      ],
+      latestLedger: 1,
+    }));
+
+    const result = await batchGetLedgerEntries(
+      fetcher,
+      ["a", "b"] as never,
+      baseOptions()
+    );
+
+    expect(result.entries).toEqual([
+      { key: "a", val: "a" },
+      null,
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("respects the concurrency limit", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const fetcher = buildFetcher(async (keys) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      return {
+        entries: keys.map((key) => ({ key, val: key })),
+        latestLedger: 1,
+      };
+    });
+
+    const keys = Array.from({ length: 6 }, (_, index) => `k${index}`);
+    await batchGetLedgerEntries(fetcher, keys as never, {
+      ...baseOptions(),
+      chunkSize: 1,
+      concurrency: 2,
+    });
+
+    expect(maxInFlight).toBe(2);
+  });
+
+  it("validates chunkSize and concurrency", async () => {
+    const fetcher = buildFetcher(() => ({ entries: [], latestLedger: 0 }));
+    await expect(
+      batchGetLedgerEntries(fetcher, ["a"] as never, {
+        ...baseOptions(),
+        chunkSize: 0,
+      })
+    ).rejects.toThrow(/chunkSize/);
+
+    await expect(
+      batchGetLedgerEntries(fetcher, ["a"] as never, {
+        ...baseOptions(),
+        concurrency: 0,
+      })
+    ).rejects.toThrow(/concurrency/);
+  });
+
+  it("uses DEFAULT_BATCH_CHUNK_SIZE when no chunkSize override is given", async () => {
+    const fetcher = buildFetcher((keys) => ({
+      entries: keys.map((key) => ({ key, val: key })),
+      latestLedger: 1,
+    }));
+
+    const keys = Array.from(
+      { length: DEFAULT_BATCH_CHUNK_SIZE + 1 },
+      (_, index) => `k${index}`
+    );
+
+    await batchGetLedgerEntries(fetcher, keys as never, baseOptions());
+
+    expect(fetcher.calls).toHaveLength(2);
+    expect(fetcher.calls[0]).toHaveLength(DEFAULT_BATCH_CHUNK_SIZE);
+    expect(fetcher.calls[1]).toHaveLength(1);
+  });
+});

--- a/soroban-client/sdk/README.md
+++ b/soroban-client/sdk/README.md
@@ -54,3 +54,32 @@ const result = await sdk.eventManager.createEvent(
 cd soroban-client
 npm run sdk:generate-types
 ```
+
+### Batch ledger-entry fetch
+
+`batchGetLedgerEntries` wraps `rpc.Server.getLedgerEntries` so callers can
+read many keys in one workflow. It chunks over the RPC's per-call key
+limit, runs chunks concurrently, aligns missing entries to `null` at
+their input index, and surfaces per-chunk RPC failures in a structured
+`errors` array instead of bubbling the first one and losing the rest.
+
+```ts
+import { batchGetLedgerEntries } from "@crowdpass/tokenbound-sdk";
+
+const result = await batchGetLedgerEntries(sdk.rpcServer, ledgerKeys);
+
+for (let i = 0; i < ledgerKeys.length; i += 1) {
+  const entry = result.entries[i];
+  if (entry === undefined) {
+    // chunk failed — see result.errors
+  } else if (entry === null) {
+    // key not present on-chain
+  } else {
+    // entry.val is the ledger data
+  }
+}
+
+// {found, missing, failed, latestLedger} are aggregated for monitoring.
+```
+
+`chunkSize`, `concurrency`, and `keyId` are all overridable.

--- a/soroban-client/sdk/src/batchLedgerEntries.ts
+++ b/soroban-client/sdk/src/batchLedgerEntries.ts
@@ -1,0 +1,244 @@
+/**
+ * Batch ledger-entry fetch helper with partial-failure handling.
+ *
+ * Soroban RPC's `getLedgerEntries` returns up to ~100 keys per call and
+ * silently omits missing keys from the response. Any non-trivial reader
+ * therefore needs to: chunk over the limit, map responses back to the
+ * original input ordering, surface missing keys as `null` rather than as
+ * an indistinguishable absence, and survive per-chunk failures (a single
+ * 5xx in a thundering-herd refresh shouldn't lose every other chunk's
+ * data). This module wraps that workflow so callers can hand it a flat
+ * `xdr.LedgerKey[]` and get back an aligned result + a structured error
+ * list.
+ *
+ * The module deliberately keeps stellar-sdk imports type-only so it stays
+ * tree-shakeable and so tests can run without pulling the SDK's runtime
+ * (which currently breaks under jsdom without a TextEncoder polyfill).
+ */
+
+import type { rpc, xdr } from "@stellar/stellar-sdk";
+
+/** Soroban RPC enforces a 100-key cap per `getLedgerEntries` call. */
+export const DEFAULT_BATCH_CHUNK_SIZE = 100;
+
+/** Default number of chunk RPCs to run in parallel. */
+export const DEFAULT_BATCH_CONCURRENCY = 4;
+
+/** Minimal shape required from the RPC client. Accepts `rpc.Server`. */
+export interface LedgerEntriesFetcher {
+  getLedgerEntries(
+    ...keys: xdr.LedgerKey[]
+  ): Promise<rpc.Api.GetLedgerEntriesResponse>;
+}
+
+export interface BatchLedgerEntriesOptions {
+  /**
+   * Maximum keys per RPC call. Defaults to {@link DEFAULT_BATCH_CHUNK_SIZE}.
+   * Must be at least 1.
+   */
+  readonly chunkSize?: number;
+
+  /**
+   * Number of chunk RPCs to run in parallel. Defaults to
+   * {@link DEFAULT_BATCH_CONCURRENCY}. Must be at least 1.
+   */
+  readonly concurrency?: number;
+
+  /**
+   * Function that computes a stable identity for a {@link xdr.LedgerKey}
+   * so response entries can be aligned with input positions. Defaults to
+   * the canonical XDR-base64 encoding.
+   */
+  readonly keyId?: (key: xdr.LedgerKey) => string;
+}
+
+export interface BatchLedgerChunkError {
+  /**
+   * Indexes (into the original input array) whose entries could not be
+   * fetched because the chunk RPC threw.
+   */
+  readonly indexes: readonly number[];
+  /** The error thrown by the RPC for this chunk. */
+  readonly error: unknown;
+}
+
+export interface BatchLedgerEntriesResult {
+  /**
+   * Aligned with the input `keys` array. `null` means the key was not
+   * present on-chain; `undefined` means the chunk that contained the key
+   * failed (see `errors`).
+   */
+  readonly entries: ReadonlyArray<rpc.Api.LedgerEntryResult | null | undefined>;
+  /** One entry per failed chunk. Empty when every chunk succeeded. */
+  readonly errors: readonly BatchLedgerChunkError[];
+  /**
+   * The most recent `latestLedger` reported across all successful chunks.
+   * `0` if every chunk failed (or input was empty).
+   */
+  readonly latestLedger: number;
+  /** Count of input keys that returned a present entry. */
+  readonly found: number;
+  /** Count of input keys whose chunks succeeded but returned no entry. */
+  readonly missing: number;
+  /** Count of input keys belonging to a failed chunk. */
+  readonly failed: number;
+}
+
+const defaultKeyId = (key: xdr.LedgerKey): string => key.toXDR("base64");
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  if (size < 1 || !Number.isFinite(size)) {
+    throw new Error(`chunkSize must be a positive integer (got ${size}).`);
+  }
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+/**
+ * Run async tasks with bounded concurrency, preserving completion order
+ * via the index passed to the worker. Errors are caught per-task by the
+ * caller (this helper does not abort sibling tasks on failure).
+ */
+async function runWithConcurrency<T>(
+  count: number,
+  concurrency: number,
+  worker: (index: number) => Promise<T>
+): Promise<T[]> {
+  if (concurrency < 1 || !Number.isFinite(concurrency)) {
+    throw new Error(
+      `concurrency must be a positive integer (got ${concurrency}).`
+    );
+  }
+  const results: T[] = new Array(count);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, count) }, async () => {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= count) {
+        return;
+      }
+      results[index] = await worker(index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * Fetch many ledger entries in one workflow.
+ *
+ * @example
+ * ```ts
+ * const result = await batchGetLedgerEntries(sdk.rpcServer, keys);
+ * for (let i = 0; i < keys.length; i += 1) {
+ *   const entry = result.entries[i];
+ *   if (entry === undefined) {
+ *     // chunk failed — see result.errors
+ *   } else if (entry === null) {
+ *     // key not found on-chain
+ *   } else {
+ *     // entry.val is the ledger data
+ *   }
+ * }
+ * ```
+ */
+export async function batchGetLedgerEntries(
+  rpcClient: LedgerEntriesFetcher,
+  keys: readonly xdr.LedgerKey[],
+  options?: BatchLedgerEntriesOptions
+): Promise<BatchLedgerEntriesResult> {
+  const chunkSize = options?.chunkSize ?? DEFAULT_BATCH_CHUNK_SIZE;
+  const concurrency = options?.concurrency ?? DEFAULT_BATCH_CONCURRENCY;
+  const keyId = options?.keyId ?? defaultKeyId;
+
+  if (keys.length === 0) {
+    return {
+      entries: [],
+      errors: [],
+      latestLedger: 0,
+      found: 0,
+      missing: 0,
+      failed: 0,
+    };
+  }
+
+  // Build a multi-map from key identity to input indexes so duplicates in
+  // the input array all receive the same response without forcing the
+  // caller to deduplicate.
+  const indexesByKeyId = new Map<string, number[]>();
+  for (let index = 0; index < keys.length; index += 1) {
+    const id = keyId(keys[index]);
+    const bucket = indexesByKeyId.get(id);
+    if (bucket) {
+      bucket.push(index);
+    } else {
+      indexesByKeyId.set(id, [index]);
+    }
+  }
+
+  const indexChunks = chunk(
+    Array.from({ length: keys.length }, (_, index) => index),
+    chunkSize
+  );
+
+  const entries: Array<rpc.Api.LedgerEntryResult | null | undefined> =
+    new Array(keys.length).fill(undefined);
+  const errors: BatchLedgerChunkError[] = [];
+  let latestLedger = 0;
+
+  await runWithConcurrency(indexChunks.length, concurrency, async (chunkIdx) => {
+    const chunkIndexes = indexChunks[chunkIdx];
+    const chunkKeys = chunkIndexes.map((index) => keys[index]);
+    let response: rpc.Api.GetLedgerEntriesResponse;
+    try {
+      response = await rpcClient.getLedgerEntries(...chunkKeys);
+    } catch (error) {
+      errors.push({ indexes: chunkIndexes, error });
+      return;
+    }
+
+    if (response.latestLedger > latestLedger) {
+      latestLedger = response.latestLedger;
+    }
+
+    // Default every index in this chunk to `null` (missing). Then fill in
+    // the entries the RPC actually returned.
+    for (const index of chunkIndexes) {
+      entries[index] = null;
+    }
+
+    for (const entry of response.entries) {
+      const id = keyId(entry.key);
+      const matchingIndexes = indexesByKeyId.get(id);
+      if (!matchingIndexes) {
+        // Defensive: RPC returned a key we didn't ask for. Skip rather
+        // than throw so the rest of the batch is still usable.
+        continue;
+      }
+      for (const index of matchingIndexes) {
+        if (chunkIndexes.includes(index)) {
+          entries[index] = entry;
+        }
+      }
+    }
+  });
+
+  let found = 0;
+  let missing = 0;
+  let failed = 0;
+  for (const entry of entries) {
+    if (entry === undefined) {
+      failed += 1;
+    } else if (entry === null) {
+      missing += 1;
+    } else {
+      found += 1;
+    }
+  }
+
+  return { entries, errors, latestLedger, found, missing, failed };
+}

--- a/soroban-client/sdk/src/index.ts
+++ b/soroban-client/sdk/src/index.ts
@@ -9,6 +9,7 @@ import {
 import { GENERATED_CONTRACT_SPECS } from "./generated/contracts";
 import type { TokenboundSdkConfig } from "./types";
 
+export * from "./batchLedgerEntries";
 export * from "./contracts";
 export * from "./core";
 export * from "./errors";


### PR DESCRIPTION
## Summary

Adds `batchGetLedgerEntries` to the tokenbound SDK, a helper for fetching many ledger entries in one workflow with partial-failure handling.

The Soroban RPC's `getLedgerEntries`:

- caps each call at ~100 keys,
- silently omits missing keys from the response,
- bubbles a single failure for the whole call.

That makes it awkward to consume directly in any read path that wants to fan-out across many keys (account state for a list of TBAs, contract data for a paginated list of events, etc.). This helper wraps the workflow so callers hand it a flat `xdr.LedgerKey[]` and get back an aligned, observable result.

## Behaviour

- **Chunking** — input is split into chunks of `chunkSize` (default `DEFAULT_BATCH_CHUNK_SIZE = 100`). Override per call if the RPC is configured differently.
- **Concurrency** — chunks run in parallel up to `concurrency` (default `DEFAULT_BATCH_CONCURRENCY = 4`).
- **Alignment** — output `entries[i]` corresponds to input `keys[i]`:
  - `LedgerEntryResult` if the entry was returned.
  - `null` if the chunk succeeded but no entry came back for that key (i.e. not present on-chain).
  - `undefined` if the chunk that contained that key failed (see `errors`).
- **Partial failures** — per-chunk RPC errors are captured in `result.errors` along with the input indexes they covered. Sibling chunks complete and contribute their entries.
- **Aggregation** — `latestLedger` is the max across successful chunks; `found` / `missing` / `failed` give a quick status read suitable for telemetry / UI badges.
- **Duplicates** — repeated input keys all receive the matching entry without an extra RPC trip per duplicate (a small request still includes both, but a single response entry is fanned back out).
- **Custom identity** — `keyId` is overridable; defaults to the canonical `key.toXDR("base64")`.

The helper takes a structural `LedgerEntriesFetcher` (the shape of `rpc.Server`), so it composes with the existing `sdk.rpcServer` and is trivial to mock. All `@stellar/stellar-sdk` imports are type-only, so the module is tree-shakeable and the tests run cleanly under jsdom (the existing repo tests break there because the SDK runtime needs a `TextEncoder` polyfill).

## Changes

- [x] New `soroban-client/sdk/src/batchLedgerEntries.ts` with `batchGetLedgerEntries`, `BatchLedgerEntriesOptions`, `BatchLedgerEntriesResult`, `BatchLedgerChunkError`, `LedgerEntriesFetcher`, and `DEFAULT_BATCH_CHUNK_SIZE` / `DEFAULT_BATCH_CONCURRENCY` constants.
- [x] Re-exported from `sdk/src/index.ts`.
- [x] New `__tests__/lib/batchLedgerEntries.test.ts` (12 unit tests).
- [x] `sdk/README.md` gains a "Batch ledger-entry fetch" section.

## Testing

```bash
cd soroban-client
npx jest __tests__/lib/batchLedgerEntries.test.ts
# → 12 passed; 0 failed

npx eslint sdk/src/batchLedgerEntries.ts __tests__/lib/batchLedgerEntries.test.ts sdk/src/index.ts
# → clean

npx tsc --noEmit  # 9 errors, all pre-existing on main, none in new files
```

The 12 tests cover:

- Empty input — short-circuits without calling the RPC.
- Single chunk — happy path, all entries returned and aligned.
- Multi-chunk — verifies the exact chunk boundaries.
- Missing keys — RPC omits entries → helper aligns `null` at the right index.
- Partial chunk failure — one chunk throws, sibling chunks still populate; `errors` records affected indexes.
- `latestLedger` is the max across successful chunks.
- All chunks fail → `latestLedger = 0`, every index is `failed`.
- Duplicate input keys all receive the matching entry.
- Stranger keys returned by the RPC (defensive) are ignored, not thrown on.
- `concurrency` is actually bounded (in-flight count never exceeds it).
- `chunkSize` / `concurrency` validation rejects 0 and non-finite values.
- Default `chunkSize` produces the expected number of RPC calls.

Full `npm test` shows 18 passing tests (was 6 on main); the same 3 unrelated, pre-existing test-suite-load failures remain — none caused by this PR. Pre-existing TS error count is unchanged at 9.

## Notes / known limitations

- **Pre-existing breakage on `main`:** three test suites fail to load on `main` (`tokenbound-sdk.test.ts`, `Hero.test.tsx`, `Footer.test.tsx`) and `npx tsc --noEmit` reports 9 pre-existing errors in `app/[locale]/create-event/page.tsx` and `lib/soroban.ts`. None are caused or worsened by this PR.
- The helper does not retry transient errors. The intent is to expose partial failure to the caller so they can decide on retry policy — adding e.g. exponential backoff on per-chunk 5xx responses is a clean follow-up.
- No automatic deduplication of repeated input keys before sending. A small efficiency optimisation would dedupe keys within each chunk; left for a follow-up because it changes the RPC argument count visibly and isn't typically a hot path.

Closes #222