### PR TITLE
Optimize gas for soroban collections length paths

### DIFF
--- a/soroban-contract/contracts/collections/src/enumerable_map.rs
+++ b/soroban-contract/contracts/collections/src/enumerable_map.rs
@@ -39,6 +39,8 @@ use soroban_sdk::Env;
 pub enum MapKey {
     /// The ordered `Vec<K>` of map keys.
     Keys(Symbol),
+    /// Cached number of entries in the map.
+    Count(Symbol),
     /// 1-based position of a key.  The `u64` is the key's raw `Val` payload.
     KeyIndex(Symbol, u64),
     /// The value stored for a key.  The `u64` is the key's raw `Val` payload.
@@ -87,6 +89,7 @@ impl EnumerableMap {
             vec.push_back(key.clone());
             let one_based = vec.len();
             tier.set(env, &keys_key, &vec);
+            tier.set(env, &MapKey::Count(ns.clone()), &one_based);
             tier.set(env, &index_key, &one_based);
         }
 
@@ -126,6 +129,7 @@ impl EnumerableMap {
 
         vec.pop_back();
         tier.set(env, &keys_key, &vec);
+        tier.set(env, &MapKey::Count(ns.clone()), &vec.len());
 
         // Delete the index and value for the removed key.
         tier.remove(env, &index_key);
@@ -160,10 +164,7 @@ impl EnumerableMap {
     where
         K: IntoVal<Env, Val> + TryFromVal<Env, Val>,
     {
-        let vec: Vec<K> = tier
-            .get(env, &MapKey::Keys(ns.clone()))
-            .unwrap_or_else(|| Vec::new(env));
-        vec.len()
+        tier.get(env, &MapKey::Count(ns.clone())).unwrap_or(0)
     }
 
     /// Returns all keys in insertion order.

--- a/soroban-contract/contracts/collections/src/enumerable_set.rs
+++ b/soroban-contract/contracts/collections/src/enumerable_set.rs
@@ -36,6 +36,8 @@ use soroban_sdk::Env;
 pub enum SetKey {
     /// The ordered `Vec<V>` of set members.
     Values(Symbol),
+    /// Cached number of elements in the set.
+    Count(Symbol),
     /// 1-based index of a member.  The second field is the member's raw `Val`
     /// payload encoded as a `u64`, avoiding XDR limitations on `Val` fields.
     Index(Symbol, u64),
@@ -84,6 +86,7 @@ impl EnumerableSet {
         let one_based_index = vec.len(); // length after push == 1-based index of new element
 
         tier.set(env, &values_key, &vec);
+        tier.set(env, &SetKey::Count(ns.clone()), &one_based_index);
         tier.set(env, &index_key, &one_based_index);
 
         true
@@ -124,6 +127,7 @@ impl EnumerableSet {
 
         vec.pop_back(); // remove last (was either target or swapped copy)
         tier.set(env, &values_key, &vec);
+        tier.set(env, &SetKey::Count(ns.clone()), &vec.len());
         tier.remove(env, &index_key);
 
         true
@@ -145,10 +149,7 @@ impl EnumerableSet {
     where
         V: IntoVal<Env, Val> + TryFromVal<Env, Val>,
     {
-        let vec: Vec<V> = tier
-            .get(env, &SetKey::Values(ns.clone()))
-            .unwrap_or_else(|| Vec::new(env));
-        vec.len()
+        tier.get(env, &SetKey::Count(ns.clone())).unwrap_or(0)
     }
 
     /// Returns all members as an ordered `Vec<V>`.

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_entries_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_entries_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "entries"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "KeyIndex"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_insert_and_get_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_insert_and_get_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "balances"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "KeyIndex"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_insert_and_remove_persistent.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_insert_and_remove_persistent.1.json
@@ -24,6 +24,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Count"
+                },
+                {
+                  "symbol": "pmap"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Count"
+                    },
+                    {
+                      "symbol": "pmap"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "Keys"
                 },
                 {

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_insert_update_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_insert_update_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "balu"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "KeyIndex"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_key_at_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_key_at_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "keyat"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "KeyIndex"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_keys_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_keys_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "mapkeys"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "KeyIndex"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_length_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_length_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "maplen"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 3
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "KeyIndex"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_namespaces_are_isolated.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_namespaces_are_isolated.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "mnsA"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "KeyIndex"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_remove_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_remove_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "maprm"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "KeyIndex"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_remove_middle_swap_correctness_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_remove_middle_swap_correctness_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "mmid"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 4
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "KeyIndex"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/map_values_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/map_values_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "mapvals"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "KeyIndex"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_at_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_at_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "at"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Index"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_contains_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_contains_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "owners"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Index"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_contains_persistent.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_contains_persistent.1.json
@@ -24,6 +24,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Count"
+                },
+                {
+                  "symbol": "powners"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Count"
+                    },
+                    {
+                      "symbol": "powners"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "Index"
                 },
                 {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_remove_temporary.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_insert_and_remove_temporary.1.json
@@ -24,6 +24,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Count"
+                },
+                {
+                  "symbol": "tmp"
+                }
+              ]
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Count"
+                    },
+                    {
+                      "symbol": "tmp"
+                    }
+                  ]
+                },
+                "durability": "temporary",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          15
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "Values"
                 },
                 {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_insert_duplicate_is_idempotent_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_insert_duplicate_is_idempotent_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "dedup"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Index"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_length_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_length_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "len"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 3
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Index"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_namespaces_are_isolated.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_namespaces_are_isolated.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "nsA"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Index"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_remove_all_elements_one_by_one.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_remove_all_elements_one_by_one.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "rmall"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Values"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_remove_and_reinsert_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_remove_and_reinsert_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "reins"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Index"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_remove_last_element_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_remove_last_element_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "rmlast"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Values"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_remove_middle_persistent.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_remove_middle_persistent.1.json
@@ -24,6 +24,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Count"
+                },
+                {
+                  "symbol": "prmid"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Count"
+                    },
+                    {
+                      "symbol": "prmid"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 3
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "Index"
                 },
                 {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_remove_middle_swap_correctness_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_remove_middle_swap_correctness_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "rmid"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 4
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Index"
                             },
                             {

--- a/soroban-contract/contracts/collections/test_snapshots/test/set_values_returns_all_members_instance.1.json
+++ b/soroban-contract/contracts/collections/test_snapshots/test/set_values_returns_all_members_instance.1.json
@@ -44,6 +44,21 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Count"
+                            },
+                            {
+                              "symbol": "vals"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 5
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Index"
                             },
                             {


### PR DESCRIPTION
## Overview
This PR optimizes gas usage in `soroban-contract/contracts/collections` by removing unnecessary full-vector loads in common read paths. It adds a cached per-namespace `Count` storage key for both `EnumerableSet` and `EnumerableMap`, so `length()` now reads a single `u32` instead of deserializing the full values/keys vector.

## Related Issue
Closes #168

## Changes

### ⚙️ Collections Gas Optimization
- **[MODIFY]** `soroban-contract/contracts/collections/src/enumerable_set.rs`
- Added `SetKey::Count(Symbol)` storage key.
- Updated `insert`/`remove` to maintain cached set length.
- Updated `length()` to read `Count` directly.

- **[MODIFY]** `soroban-contract/contracts/collections/src/enumerable_map.rs`
- Added `MapKey::Count(Symbol)` storage key.
- Updated `insert`/`remove` to maintain cached map length.
- Updated `length()` to read `Count` directly.

### 🧪 Test Snapshots
- **[MODIFY]** `soroban-contract/contracts/collections/test_snapshots/test/*.json`
- Updated snapshots to reflect the new `Count` entries in instance/persistent storage for affected set/map scenarios.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| `EnumerableSet::length()` avoids full vector load | ✅ |
| `EnumerableMap::length()` avoids full vector load | ✅ |
| Insert/remove semantics remain intact | ✅ |
| Collections test suite passes | ✅ |

## How to Test

```bash
# 1. Confirm you're on the branch
git branch --show-current

# 2. Run the collections tests
cd soroban-contract
cargo test -p collections

# 3. Optional: inspect changed files
git diff -- contracts/collections/src/enumerable_set.rs contracts/collections/src/enumerable_map.rs contracts/collections/test_snapshots/test
```

## Screenshots

### ✅ Collections tests pass
Please run and attach a screenshot of:

```bash
[cargo test -p collections in soroban-contract]
```

<img width="533" height="507" alt="image" src="https://github.com/user-attachments/assets/1f6c62ab-cdf3-43ea-a4cb-5ab07674364b" />


