### PR TITLE
feat: add ERC-721 NFT demo page for Soroban TicketNFT contract

### DIFF
--- a/soroban-client/app/examples/nft721/page.tsx
+++ b/soroban-client/app/examples/nft721/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { SorobanProvider } from "@/contexts/SorobanContext";
+import { WalletProvider } from "@/contexts/WalletContext";
+import { NFT721Demo } from "@/components/examples/NFT721Demo";
+
+const sorobanConfig = {
+  horizonUrl:
+    process.env.NEXT_PUBLIC_HORIZON_URL || "https://horizon-testnet.stellar.org",
+  sorobanRpcUrl:
+    process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ||
+    "https://soroban-testnet.stellar.org",
+  networkPassphrase:
+    process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ||
+    "Test SDF Network ; September 2015",
+  contracts: {
+    ticketNft: process.env.NEXT_PUBLIC_TICKET_NFT_CONTRACT || "",
+  },
+};
+
+export default function NFT721Page() {
+  return (
+    <WalletProvider>
+      <SorobanProvider config={sorobanConfig}>
+        <div className="min-h-screen bg-gray-50">
+          <div className="max-w-4xl mx-auto px-4 py-8">
+            <header className="mb-8">
+              <h1 className="text-3xl font-bold mb-2">ERC-721 NFT Demo</h1>
+              <p className="text-gray-600">
+                Interact with the <strong>TicketNFT</strong> Soroban contract — an
+                ERC-721 compliant NFT deployed on Stellar testnet.
+              </p>
+            </header>
+
+            <main className="bg-white rounded-lg shadow-sm p-6">
+              <NFT721Demo />
+            </main>
+
+            <footer className="mt-6 text-xs text-gray-500 text-center">
+              Set <code>NEXT_PUBLIC_TICKET_NFT_CONTRACT</code> in{" "}
+              <code>.env.local</code> to point at your deployed contract.
+            </footer>
+          </div>
+        </div>
+      </SorobanProvider>
+    </WalletProvider>
+  );
+}

--- a/soroban-client/components/examples/NFT721Demo.tsx
+++ b/soroban-client/components/examples/NFT721Demo.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useSoroban } from "@/contexts/SorobanContext";
+import { useWallet } from "@/contexts/WalletContext";
+import {
+  useOwnerOf,
+  useBalanceOf,
+  useIsValid,
+  useTransferNFT,
+} from "@/hooks/useTicketNFT";
+
+// ── Read panel: query ownerOf / balanceOf / isValid ──────────────────────────
+
+function ReadPanel() {
+  const { sdk } = useSoroban();
+  const [tokenId, setTokenId] = useState<string>("1");
+  const [ownerQuery, setOwnerQuery] = useState<bigint>(1n);
+  const [balanceAddr, setBalanceAddr] = useState<string>("");
+  const [validQuery, setValidQuery] = useState<bigint>(1n);
+
+  const { data: owner, loading: ownerLoading, error: ownerError, refetch: refetchOwner } =
+    useOwnerOf(sdk, ownerQuery, { enabled: false });
+
+  const { data: balance, loading: balLoading, error: balError, refetch: refetchBalance } =
+    useBalanceOf(sdk, balanceAddr, { enabled: false });
+
+  const { data: isValid, loading: validLoading, error: validError, refetch: refetchValid } =
+    useIsValid(sdk, validQuery, { enabled: false });
+
+  return (
+    <div className="space-y-6">
+      {/* ownerOf */}
+      <div className="border rounded-lg p-4">
+        <h3 className="font-semibold mb-3">ownerOf(tokenId)</h3>
+        <div className="flex gap-2">
+          <input
+            type="number"
+            min="1"
+            value={tokenId}
+            onChange={(e) => {
+              setTokenId(e.target.value);
+              setOwnerQuery(BigInt(e.target.value || "1"));
+            }}
+            className="flex-1 px-3 py-2 border rounded text-sm"
+            placeholder="Token ID"
+          />
+          <button
+            onClick={() => refetchOwner()}
+            disabled={ownerLoading}
+            className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:bg-gray-400"
+          >
+            {ownerLoading ? "…" : "Query"}
+          </button>
+        </div>
+        {ownerError && <p className="mt-2 text-sm text-red-600">{ownerError.message}</p>}
+        {owner && <p className="mt-2 text-sm font-mono break-all text-green-700">{owner}</p>}
+      </div>
+
+      {/* balanceOf */}
+      <div className="border rounded-lg p-4">
+        <h3 className="font-semibold mb-3">balanceOf(address)</h3>
+        <div className="flex gap-2">
+          <input
+            value={balanceAddr}
+            onChange={(e) => setBalanceAddr(e.target.value)}
+            className="flex-1 px-3 py-2 border rounded text-sm font-mono"
+            placeholder="G... Stellar address"
+          />
+          <button
+            onClick={() => refetchBalance()}
+            disabled={balLoading || !balanceAddr}
+            className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:bg-gray-400"
+          >
+            {balLoading ? "…" : "Query"}
+          </button>
+        </div>
+        {balError && <p className="mt-2 text-sm text-red-600">{balError.message}</p>}
+        {balance !== null && balance !== undefined && (
+          <p className="mt-2 text-sm text-green-700">Balance: <strong>{balance.toString()}</strong></p>
+        )}
+      </div>
+
+      {/* isValid */}
+      <div className="border rounded-lg p-4">
+        <h3 className="font-semibold mb-3">isValid(tokenId)</h3>
+        <div className="flex gap-2">
+          <input
+            type="number"
+            min="1"
+            value={validQuery.toString()}
+            onChange={(e) => setValidQuery(BigInt(e.target.value || "1"))}
+            className="flex-1 px-3 py-2 border rounded text-sm"
+            placeholder="Token ID"
+          />
+          <button
+            onClick={() => refetchValid()}
+            disabled={validLoading}
+            className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:bg-gray-400"
+          >
+            {validLoading ? "…" : "Query"}
+          </button>
+        </div>
+        {validError && <p className="mt-2 text-sm text-red-600">{validError.message}</p>}
+        {isValid !== null && isValid !== undefined && (
+          <p className={`mt-2 text-sm font-semibold ${isValid ? "text-green-700" : "text-red-600"}`}>
+            Token is {isValid ? "valid ✓" : "invalid ✗"}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Write panel: transferFrom ─────────────────────────────────────────────────
+
+function TransferPanel() {
+  const { sdk } = useSoroban();
+  const { address, signTransaction, isConnected } = useWallet();
+
+  const [from, setFrom] = useState<string>("");
+  const [to, setTo] = useState<string>("");
+  const [tokenId, setTokenId] = useState<bigint>(1n);
+
+  const signFn = useCallback(
+    (xdr: string, opts: { networkPassphrase: string; address: string }) =>
+      signTransaction(xdr, opts),
+    [signTransaction]
+  );
+
+  const { write, loading, error, isSuccess, reset } = useTransferNFT(
+    sdk,
+    from || address || "",
+    to,
+    tokenId,
+    { signTransaction: signFn }
+  );
+
+  const handleTransfer = async () => {
+    if (!isConnected) {
+      alert("Connect your wallet first");
+      return;
+    }
+    await write();
+  };
+
+  if (isSuccess) {
+    return (
+      <div className="border border-green-200 bg-green-50 rounded-lg p-4">
+        <p className="text-green-800 font-semibold">Transfer submitted ✓</p>
+        <button onClick={reset} className="mt-3 text-sm text-green-700 underline">
+          Make another transfer
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border rounded-lg p-4 space-y-3">
+      <h3 className="font-semibold">transferFrom(from, to, tokenId)</h3>
+
+      <div>
+        <label className="block text-xs text-gray-500 mb-1">From (leave blank to use connected wallet)</label>
+        <input
+          value={from}
+          onChange={(e) => setFrom(e.target.value)}
+          className="w-full px-3 py-2 border rounded text-sm font-mono"
+          placeholder={address || "G... Stellar address"}
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs text-gray-500 mb-1">To *</label>
+        <input
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+          className="w-full px-3 py-2 border rounded text-sm font-mono"
+          placeholder="G... recipient address"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs text-gray-500 mb-1">Token ID *</label>
+        <input
+          type="number"
+          min="1"
+          value={tokenId.toString()}
+          onChange={(e) => setTokenId(BigInt(e.target.value || "1"))}
+          className="w-full px-3 py-2 border rounded text-sm"
+        />
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded p-3 text-sm text-red-800">
+          {error.message}
+        </div>
+      )}
+
+      <button
+        onClick={handleTransfer}
+        disabled={loading || !to}
+        className="w-full px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+      >
+        {loading ? "Submitting…" : "Transfer NFT"}
+      </button>
+
+      {!isConnected && (
+        <p className="text-xs text-gray-500 text-center">Connect your wallet to sign transactions</p>
+      )}
+    </div>
+  );
+}
+
+// ── Main demo component ───────────────────────────────────────────────────────
+
+type Tab = "read" | "transfer";
+
+export function NFT721Demo() {
+  const [tab, setTab] = useState<Tab>("read");
+
+  const tabs: { id: Tab; label: string }[] = [
+    { id: "read", label: "Read (ownerOf / balanceOf / isValid)" },
+    { id: "transfer", label: "Write (transferFrom)" },
+  ];
+
+  return (
+    <div className="max-w-2xl">
+      {/* Contract info banner */}
+      <div className="mb-6 bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm">
+        <p className="font-semibold text-blue-900 mb-1">ERC-721 on Soroban — TicketNFT contract</p>
+        <p className="text-blue-700">
+          The <code className="bg-blue-100 px-1 rounded">ticket_nft</code> contract implements
+          ERC-721 semantics: each token has a unique owner, supports{" "}
+          <code className="bg-blue-100 px-1 rounded">ownerOf</code>,{" "}
+          <code className="bg-blue-100 px-1 rounded">balanceOf</code>, and{" "}
+          <code className="bg-blue-100 px-1 rounded">transferFrom</code>.
+          Calls are made via the <code className="bg-blue-100 px-1 rounded">useTicketNFT</code> hooks
+          which wrap <code className="bg-blue-100 px-1 rounded">useSorobanContractRead/Write</code>.
+        </p>
+      </div>
+
+      {/* Tabs */}
+      <div className="border-b mb-6">
+        <nav className="flex space-x-4">
+          {tabs.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setTab(id)}
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                tab === id
+                  ? "border-blue-600 text-blue-600"
+                  : "border-transparent text-gray-600 hover:text-gray-900"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {tab === "read" && <ReadPanel />}
+      {tab === "transfer" && <TransferPanel />}
+    </div>
+  );
+}


### PR DESCRIPTION

Adds a frontend example demonstrating how to interact with an ERC-721 compliant contract (`ticket_nft`) deployed on Soroban. The demo lives at `/examples/nft721` inside `soroban-client` and is built entirely on top of the existing hooks and SDK — no new dependencies introduced.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- `soroban-client/components/examples/NFT721Demo.tsx` — reusable demo component with two panels:
  - **Read** — `ownerOf(tokenId)`, `balanceOf(address)`, `isValid(tokenId)` via `useOwnerOf`, `useBalanceOf`, `useIsValid`
  - **Write** — `transferFrom(from, to, tokenId)` via `useTransferNFT`, requiring a connected wallet to sign
- `soroban-client/app/examples/nft721/page.tsx` — Next.js route (`/examples/nft721`) wrapping the component in `SorobanProvider` + `WalletProvider`

## Testing

- [x] `tsc --noEmit` passes with zero errors on the new files
- [x] Follows the same hook/context patterns as `PurchaseTicket.tsx` and the existing `soroban-integration` page
- [ ] Manual end-to-end test against a deployed `ticket_nft` contract on testnet (requires `NEXT_PUBLIC_TICKET_NFT_CONTRACT` set in `.env.local`)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] No new dependencies added

## Additional Notes

- Queries use `enabled: false` so they only fire on explicit button click, not on mount — appropriate for a demo/explorer UI.
- The `from` field in the transfer panel defaults to the connected wallet address if left blank.
- Set `NEXT_PUBLIC_TICKET_NFT_CONTRACT` in `.env.local` to point at the deployed contract before testing.

closes #172
