### PR TITLE
refactor(soroban-contract): pack instance storage for efficiency (#166)

### DIFF
--- a/soroban-contract/contracts/collections/src/storage_type.rs
+++ b/soroban-contract/contracts/collections/src/storage_type.rs
@@ -21,6 +21,7 @@ pub enum StorageTier {
 
 impl StorageTier {
     /// Read a value from the selected storage tier.
+    #[inline]
     pub fn get<K, V>(&self, env: &Env, key: &K) -> Option<V>
     where
         K: IntoVal<Env, Val>,
@@ -34,6 +35,7 @@ impl StorageTier {
     }
 
     /// Write a value to the selected storage tier.
+    #[inline]
     pub fn set<K, V>(&self, env: &Env, key: &K, val: &V)
     where
         K: IntoVal<Env, Val>,
@@ -47,6 +49,7 @@ impl StorageTier {
     }
 
     /// Remove a key from the selected storage tier.
+    #[inline]
     pub fn remove<K>(&self, env: &Env, key: &K)
     where
         K: IntoVal<Env, Val>,
@@ -59,6 +62,7 @@ impl StorageTier {
     }
 
     /// Check whether a key exists in the selected storage tier.
+    #[inline]
     pub fn has<K>(&self, env: &Env, key: &K) -> bool
     where
         K: IntoVal<Env, Val>,

--- a/soroban-contract/contracts/event_manager/src/lib.rs
+++ b/soroban-contract/contracts/event_manager/src/lib.rs
@@ -67,20 +67,24 @@ pub struct EventLedger {
     pub withdrawn: bool,
 }
 
+/// Packed POAP + TBA integration config (one instance read in `distribute_poaps`).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PoapIntegration {
+    pub tba_registry: Address,
+    pub tba_implementation_hash: BytesN<32>,
+    pub tba_salt: BytesN<32>,
+    pub poap_nft: Address,
+}
+
 #[contracttype]
 pub enum DataKey {
     Event(u32),
     ArchivedEvent(u32),
     EventCounter,
     TicketFactory,
-    /// Optional: TBA registry address used to resolve ticket TBAs
-    TbaRegistry,
-    /// Optional: TBA implementation hash (see `tba_registry::{get_account,create_account}`)
-    TbaImplementationHash,
-    /// Optional: TBA salt used to derive deterministic TBAs
-    TbaSalt,
-    /// POAP contract (minter should be this EventManager)
-    PoapNft,
+    /// POAP distribution + deterministic TBA resolution (packed).
+    PoapIntegration,
     RefundClaimed(u32, Address),
     EventBuyers(u32),
     EventTiers(u32),
@@ -298,14 +302,15 @@ impl EventManager {
     ) -> Result<(), Error> {
         upg::require_admin(&env);
 
+        let cfg = PoapIntegration {
+            tba_registry,
+            tba_implementation_hash,
+            tba_salt,
+            poap_nft,
+        };
         env.storage()
             .instance()
-            .set(&DataKey::TbaRegistry, &tba_registry);
-        env.storage()
-            .instance()
-            .set(&DataKey::TbaImplementationHash, &tba_implementation_hash);
-        env.storage().instance().set(&DataKey::TbaSalt, &tba_salt);
-        env.storage().instance().set(&DataKey::PoapNft, &poap_nft);
+            .set(&DataKey::PoapIntegration, &cfg);
         upg::extend_instance_ttl(&env);
         Ok(())
     }
@@ -391,26 +396,10 @@ impl EventManager {
             return Ok(0);
         }
 
-        let poap_addr: Address = env
+        let cfg: PoapIntegration = env
             .storage()
             .instance()
-            .get(&DataKey::PoapNft)
-            .ok_or(Error::FactoryNotInitialized)?;
-
-        let tba_registry: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::TbaRegistry)
-            .ok_or(Error::FactoryNotInitialized)?;
-        let impl_hash: BytesN<32> = env
-            .storage()
-            .instance()
-            .get(&DataKey::TbaImplementationHash)
-            .ok_or(Error::FactoryNotInitialized)?;
-        let salt: BytesN<32> = env
-            .storage()
-            .instance()
-            .get(&DataKey::TbaSalt)
+            .get(&DataKey::PoapIntegration)
             .ok_or(Error::FactoryNotInitialized)?;
 
         // STORAGE: attendees list lives in `temporary` storage (see
@@ -444,14 +433,14 @@ impl EventManager {
 
             // Resolve deterministic ticket TBA.
             let tba_addr: Address = env.invoke_contract(
-                &tba_registry,
+                &cfg.tba_registry,
                 &Symbol::new(&env, "get_account"),
                 soroban_sdk::vec![
                     &env,
-                    impl_hash.clone().into_val(&env),
+                    cfg.tba_implementation_hash.clone().into_val(&env),
                     event.ticket_nft_addr.clone().into_val(&env),
                     token_id.into_val(&env),
-                    salt.clone().into_val(&env),
+                    cfg.tba_salt.clone().into_val(&env),
                 ],
             );
 
@@ -464,7 +453,7 @@ impl EventManager {
                 issued_at: env.ledger().timestamp(),
             };
             env.invoke_contract::<u128>(
-                &poap_addr,
+                &cfg.poap_nft,
                 &Symbol::new(&env, "mint_poap"),
                 soroban_sdk::vec![&env, tba_addr.into_val(&env), poap_md.into_val(&env),],
             );
@@ -787,17 +776,6 @@ impl EventManager {
         env.events()
             .publish((Symbol::new(&env, "RefundClaimed"),), event);
 
-    pub fn initialize_legacy(env: Env, ticket_factory: Address) -> Result<(), Error> {
-        if env.storage().instance().has(&DataKey::TicketFactory) {
-            return Err(Error::AlreadyInitialized);
-        }
-        upg::set_admin(&env, &ticket_factory);
-        upg::init_version(&env);
-        env.storage()
-            .instance()
-            .set(&DataKey::TicketFactory, &ticket_factory);
-        env.storage().instance().set(&DataKey::EventCounter, &0u32);
-        upg::extend_instance_ttl(&env);
         Ok(())
     }
 

--- a/soroban-contract/contracts/ticket_factory/src/lib.rs
+++ b/soroban-contract/contracts/ticket_factory/src/lib.rs
@@ -28,11 +28,12 @@ pub enum Error {
     Unauthorized = 2,
 }
 
-/// Storage keys for the contract state
+/// Storage keys for the contract state.
+///
+/// Admin lives only in [`upgradeable::UpgradeKey::Admin`] (see `upg::set_admin`);
+/// duplicating it here wasted an instance slot and an extra write on init.
 #[contracttype]
 pub enum DataKey {
-    /// Factory administrator address
-    Admin,
     /// WASM hash of the Ticket NFT contract to deploy
     TicketWasmHash,
     /// Total number of ticket contracts deployed
@@ -58,7 +59,6 @@ impl TicketFactory {
     pub fn __constructor(env: Env, admin: Address, ticket_wasm_hash: BytesN<32>) {
         upg::set_admin(&env, &admin);
         upg::init_version(&env);
-        env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage()
             .instance()
             .set(&DataKey::TicketWasmHash, &ticket_wasm_hash);
@@ -87,11 +87,7 @@ impl TicketFactory {
     /// Requires admin authorization
     pub fn deploy_ticket(env: Env, minter: Address, salt: BytesN<32>) -> Result<Address, Error> {
         // Authorize: only admin can deploy
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::NotInitialized)?;
+        let admin: Address = upg::try_get_admin(&env).ok_or(Error::NotInitialized)?;
         admin.require_auth();
 
         // Get the WASM hash for deployment
@@ -197,11 +193,7 @@ impl TicketFactory {
     /// # Returns
     /// The admin address
     pub fn get_admin(env: Env) -> Result<Address, Error> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::NotInitialized)?;
+        let admin: Address = upg::try_get_admin(&env).ok_or(Error::NotInitialized)?;
 
         // Extend instance TTL on read
         upg::extend_instance_ttl(&env);

--- a/soroban-contract/contracts/ticket_nft/src/lib.rs
+++ b/soroban-contract/contracts/ticket_nft/src/lib.rs
@@ -46,6 +46,14 @@ pub struct OffChainMetadata {
     pub updated_at: u64,
 }
 
+/// Packed instance storage: minter + monotonic id (one read/write on mint).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TicketNftCore {
+    pub minter: Address,
+    pub next_token_id: u128,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EventInfo {
@@ -78,8 +86,8 @@ pub struct OffChainUpdatedEvent {
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
-    Minter,
-    NextTokenId,
+    /// Minting authority + next token id (packed).
+    Core,
     Owner(u128),
     Balance(Address),
     Metadata(u128),
@@ -95,18 +103,21 @@ impl TicketNft {
     pub fn __constructor(env: Env, minter: Address) {
         upg::set_admin(&env, &minter);
         upg::init_version(&env);
-        env.storage().instance().set(&DataKey::Minter, &minter);
-        env.storage().instance().set(&DataKey::NextTokenId, &1u128);
+        let core = TicketNftCore {
+            minter: minter.clone(),
+            next_token_id: 1,
+        };
+        env.storage().instance().set(&DataKey::Core, &core);
         upg::extend_instance_ttl(&env);
     }
 
     pub fn mint_ticket_nft(env: Env, recipient: Address) -> Result<u128, Error> {
-        let minter: Address = env
+        let mut core: TicketNftCore = env
             .storage()
             .instance()
-            .get(&DataKey::Minter)
+            .get(&DataKey::Core)
             .ok_or(Error::NotInitialized)?;
-        minter.require_auth();
+        core.minter.require_auth();
 
         let current_balance: u128 = env
             .storage()
@@ -118,11 +129,8 @@ impl TicketNft {
             return Err(Error::UserAlreadyHasTicket);
         }
 
-        let token_id: u128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::NextTokenId)
-            .unwrap_or(1);
+        let token_id = core.next_token_id;
+        core.next_token_id = token_id.checked_add(1).unwrap();
 
         env.storage()
             .persistent()
@@ -142,9 +150,7 @@ impl TicketNft {
             .persistent()
             .set(&DataKey::Metadata(token_id), &metadata);
 
-        env.storage()
-            .instance()
-            .set(&DataKey::NextTokenId, &(token_id + 1));
+        env.storage().instance().set(&DataKey::Core, &core);
 
         Self::extend_persistent_ttl(&env, &DataKey::Owner(token_id));
         Self::extend_persistent_ttl(&env, &DataKey::Balance(recipient.clone()));
@@ -390,10 +396,12 @@ impl TicketNft {
     }
 
     pub fn get_minter(env: Env) -> Result<Address, Error> {
-        env.storage()
+        let core: TicketNftCore = env
+            .storage()
             .instance()
-            .get(&DataKey::Minter)
-            .ok_or(Error::NotInitialized)
+            .get(&DataKey::Core)
+            .ok_or(Error::NotInitialized)?;
+        Ok(core.minter)
     }
 
     pub fn schedule_upgrade(env: Env, new_wasm_hash: BytesN<32>) {
@@ -461,8 +469,9 @@ impl TicketNft {
         let minter: Address = env
             .storage()
             .instance()
-            .get(&DataKey::Minter)
-            .ok_or(Error::NotInitialized)?;
+            .get::<_, TicketNftCore>(&DataKey::Core)
+            .ok_or(Error::NotInitialized)?
+            .minter;
         minter.require_auth();
         Ok(())
     }

--- a/soroban-contract/contracts/upgradeable/src/lib.rs
+++ b/soroban-contract/contracts/upgradeable/src/lib.rs
@@ -78,11 +78,14 @@ pub fn set_admin(env: &Env, admin: &Address) {
     env.storage().instance().set(&UpgradeKey::Admin, admin);
 }
 
+/// Returns the admin address when the contract has been initialized.
+#[inline]
+pub fn try_get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&UpgradeKey::Admin)
+}
+
 pub fn get_admin(env: &Env) -> Address {
-    env.storage()
-        .instance()
-        .get(&UpgradeKey::Admin)
-        .expect("admin not set")
+    try_get_admin(env).expect("admin not set")
 }
 
 pub fn require_admin(env: &Env) {


### PR DESCRIPTION
## Summary

Refactors core Soroban **instance** storage in CrowdPass contracts to cut redundant keys, reduce read/write rounds on hot paths, and align with packed-storage patterns already used elsewhere (e.g. `EventLedger`, `OrganizerLimits`).

Closes #166.

## Changes

### `upgradeable`

- Add **`try_get_admin`** so dependents can read admin without panicking and without duplicating `UpgradeKey::Admin`.

### `ticket_factory`

- Drop **`DataKey::Admin`**; factory admin is only **`upgradeable::UpgradeKey::Admin`** (no second instance slot or duplicate write on `__constructor`).
- **`deploy_ticket`** / **`get_admin`** use **`upg::try_get_admin`**.

### `ticket_nft`

- Replace separate **`Minter`** + **`NextTokenId`** instance keys with a single **`DataKey::Core`** → **`TicketNftCore { minter, next_token_id }`** (one read + one write on mint vs two of each).

### `event_manager`

- Replace four POAP/TBA instance keys with **`PoapIntegration`** under **`DataKey::PoapIntegration`**.
- **`configure_poap`**: one **`set`** instead of four.
- **`distribute_poaps`**: one **`get`** instead of four per invocation.
- Fix **`claim_refund`**: close function correctly and remove an erroneous duplicate **`initialize_legacy`** block that broke the `impl` structure.

### `collections`

- Mark **`StorageTier::get` / `set` / `has` / `remove`** **`#[inline]`** for enumerable map/set hot paths.

## Migration / operations

- **New deploys**: use this layout as-is.
- **Existing on-chain instances** of `ticket_nft`, `event_manager`, or `ticket_factory` need an explicit **migration** (or redeploy) if old keys are already written—this PR does not add lazy migration.

## How to test

```bash
cd soroban-contract
cargo check -p event_manager -p ticket_nft -p ticket_factory -p upgradeable -p collections
# WASM (toolchain per Soroban SDK / project docs, e.g. wasm32v1-none)
cargo build --target wasm32v1-none --release
```

## Checklist

- [x] Focused storage refactors; no unrelated churn
- [ ] CI / integration snapshots updated if your pipeline asserts ledger JSON (not run from this environment)
- [x] `Fixes #166` in commit message (or this PR description) for auto-close when merged
